### PR TITLE
Return snapshot tokens in read_relationships

### DIFF
--- a/crates/kraalzibar-server/src/grpc/relationship_service.rs
+++ b/crates/kraalzibar-server/src/grpc/relationship_service.rs
@@ -113,7 +113,7 @@ where
             Some(1000)
         };
 
-        let tuples = self
+        let output = self
             .service
             .read_relationships(&tenant_id, &filter, consistency, limit)
             .await
@@ -123,13 +123,14 @@ where
             m.record_method_request("read_relationships", start.elapsed());
         }
 
-        let relationships: Vec<_> = tuples
+        let relationships: Vec<_> = output
+            .tuples
             .iter()
             .map(conversions::domain_tuple_to_proto)
             .collect();
 
         Ok(Response::new(v1::ReadRelationshipsResponse {
-            read_at: None,
+            read_at: conversions::snapshot_to_zed_token(output.snapshot),
             relationships,
         }))
     }

--- a/crates/kraalzibar-server/src/rest/types.rs
+++ b/crates/kraalzibar-server/src/rest/types.rs
@@ -122,6 +122,8 @@ pub struct RelationshipFilterRequest {
 #[derive(Debug, Serialize)]
 pub struct ReadRelationshipsResponse {
     pub relationships: Vec<RelationshipResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_at: Option<String>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary
- Add `ReadRelationshipsOutput` type to service layer so the snapshot resolved by `read_relationships` is returned alongside tuples
- Wire snapshot through gRPC `read_at` ZedToken and REST `read_at` string field
- `FullConsistency` returns a concrete snapshot; `MinimizeLatency` returns `None` (omitted in REST via `skip_serializing_if`)

## Test plan
- [x] Service-level tests: `read_relationships_returns_snapshot_with_full_consistency`, `read_relationships_returns_no_snapshot_with_minimize_latency`
- [x] REST integration tests: `read_relationships_returns_snapshot_with_full_consistency`, `read_relationships_omits_snapshot_without_consistency`
- [x] All existing tests pass unchanged
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)