### PR TITLE
Optimize lookup_resources with list_object_ids

### DIFF
--- a/crates/kraalzibar-server/src/service.rs
+++ b/crates/kraalzibar-server/src/service.rs
@@ -373,16 +373,9 @@ where
         let store = Arc::new(store);
         let snapshot = self.resolve_snapshot(&*store, input.consistency).await?;
 
-        let filter = TupleFilter {
-            object_type: Some(input.resource_type.clone()),
-            ..Default::default()
-        };
-        let tuples = store.read(&filter, snapshot, None).await?;
-
-        let mut object_ids: Vec<String> =
-            tuples.iter().map(|t| t.object.object_id.clone()).collect();
-        object_ids.sort();
-        object_ids.dedup();
+        let object_ids = store
+            .list_object_ids(&input.resource_type, snapshot, None)
+            .await?;
 
         let schema = self.load_schema_cached(tenant_id, &*store).await?;
 
@@ -524,6 +517,16 @@ mod tests {
         }
         async fn snapshot(&self) -> Result<ST, StorageError> {
             self.inner.snapshot().await
+        }
+        async fn list_object_ids(
+            &self,
+            object_type: &str,
+            snapshot: Option<ST>,
+            limit: Option<usize>,
+        ) -> Result<Vec<String>, StorageError> {
+            self.inner
+                .list_object_ids(object_type, snapshot, limit)
+                .await
         }
     }
 

--- a/crates/kraalzibar-storage/src/traits.rs
+++ b/crates/kraalzibar-storage/src/traits.rs
@@ -27,6 +27,13 @@ pub trait RelationshipStore: Send + Sync {
     ) -> impl Future<Output = Result<Vec<Tuple>, StorageError>> + Send;
 
     fn snapshot(&self) -> impl Future<Output = Result<SnapshotToken, StorageError>> + Send;
+
+    fn list_object_ids(
+        &self,
+        object_type: &str,
+        snapshot: Option<SnapshotToken>,
+        limit: Option<usize>,
+    ) -> impl Future<Output = Result<Vec<String>, StorageError>> + Send;
 }
 
 pub trait SchemaStore: Send + Sync {


### PR DESCRIPTION
## Summary
- Add `list_object_ids` to `RelationshipStore` trait so `lookup_resources` fetches only distinct object IDs instead of loading all full tuples
- For a type with many tuples, this avoids materializing every field into memory just to extract unique IDs
- Implemented for both `InMemoryStore` (filter + sort + dedup) and `PostgresStore` (`SELECT DISTINCT object_id ... ORDER BY object_id`)

## Test plan
- [x] 6 new InMemory tests: distinct IDs, snapshot filtering, limit, deleted excluded, unknown type, snapshot-ahead error
- [x] 1 `#[ignore]` Postgres integration test covering all scenarios
- [x] Existing `lookup_resources` service tests pass unchanged
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)