### PR TITLE
fix: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
     name: Docker Build & Health Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build and start services
         working-directory: docker

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,16 +14,16 @@ jobs:
     name: Check, Test, Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
 
       - name: Check formatting
         run: cargo fmt --check

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -17,9 +17,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.22"
           cache-dependency-path: sdks/go/go.sum

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -15,9 +15,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 


### PR DESCRIPTION
## Summary
- Pin all 3rd-party GitHub Actions to full SHA-1 commit hashes to prevent supply chain attacks (Aikido finding)
- Pinned: `actions/checkout`, `actions/setup-go`, `actions/setup-node`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`
- Tag comments preserved for readability (e.g., `@34e1148... # v4`)

## Aikido findings status

| Finding | Status | Notes |
|---------|--------|-------|
| Pin 3rd party GitHub Actions | **Fixed** | This PR |
| rustls-pemfile unmaintained | **Dev-dep only** | Transitive via `testcontainers` → `bollard 0.19`. bollard 0.20 drops it, but `testcontainers-modules 0.14` (latest) requires `testcontainers 0.26` which uses bollard 0.19. Blocked upstream. |
| http crate upgrade | **Dev-dep only** | `http 0.2.12` is pulled in via `axum-test 16` → `rust-multipart-rfc7578_2`. Production code uses `http 1.4.0` (fixed). `axum-test 17+` requires `axum 0.8` — upgrading axum is a separate effort. |

## Test plan
- [ ] Verify CI workflows run correctly with pinned SHAs
- [ ] Confirm no Cargo dependency changes (lockfile unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)