### PR TITLE
Replace Jaeger with OTel Collector + Tempo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,22 @@ cd sdks/typescript && npm test
 
 ### Docker Compose
 
-The full observability stack includes PostgreSQL, Prometheus, Jaeger, and Grafana:
+The full observability stack includes PostgreSQL, Prometheus, OTel Collector,
+Tempo, and Grafana:
 
 ```bash
 cd docker && docker compose up -d
 ```
 
-| Service    | URL                        | Purpose                    |
-|------------|----------------------------|----------------------------|
-| gRPC       | `localhost:50051`          | gRPC API                   |
-| REST       | `localhost:8080`           | REST API + `/metrics`      |
-| Prometheus | `http://localhost:9090`    | Metrics dashboard          |
-| Jaeger     | `http://localhost:16686`   | Distributed traces         |
-| Grafana    | `http://localhost:3000`    | Dashboards (admin/admin)   |
-| PostgreSQL | `localhost:5432`           | Persistent storage         |
+| Service        | URL                        | Purpose                       |
+|----------------|----------------------------|-------------------------------|
+| gRPC           | `localhost:50051`          | gRPC API                      |
+| REST           | `localhost:8080`           | REST API + `/metrics`         |
+| Prometheus     | `http://localhost:9090`    | Metrics storage + queries     |
+| OTel Collector | `localhost:4317`           | OTLP trace pipeline           |
+| Tempo          | `http://localhost:3200`    | Trace storage (TraceQL)       |
+| Grafana        | `http://localhost:3000`    | Dashboards (admin/admin)      |
+| PostgreSQL     | `localhost:5432`           | Persistent storage            |
 
 ### Configuration
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,11 +27,11 @@ services:
       KRAALZIBAR_LOG_FORMAT: "json"
       KRAALZIBAR_LOG_LEVEL: "info"
       KRAALZIBAR_TRACING_ENABLED: "true"
-      KRAALZIBAR_TRACING_OTLP_ENDPOINT: "http://jaeger:4317"
+      KRAALZIBAR_TRACING_OTLP_ENDPOINT: "http://otel-collector:4317"
     depends_on:
       postgres:
         condition: service_healthy
-      jaeger:
+      otel-collector:
         condition: service_healthy
 
   prometheus:
@@ -43,16 +43,28 @@ services:
     depends_on:
       - server
 
-  jaeger:
-    image: jaegertracing/all-in-one:latest
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    volumes:
+      - ./otel-collector.yml:/etc/otelcol-contrib/config.yaml:ro
     ports:
       - "4317:4317"
-      - "16686:16686"
+    depends_on:
+      - tempo
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:14269/ || exit 1"]
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:13133/"]
       interval: 5s
       timeout: 5s
       retries: 5
+
+  tempo:
+    image: grafana/tempo:latest
+    command: ["-config.file=/etc/tempo.yml"]
+    volumes:
+      - ./tempo.yml:/etc/tempo.yml:ro
+      - tempo-data:/var/tempo
+    ports:
+      - "3200:3200"
 
   grafana:
     image: grafana/grafana:latest
@@ -66,7 +78,8 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
-      - jaeger
+      - tempo
 
 volumes:
   pgdata:
+  tempo-data:

--- a/docker/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/docker/grafana/provisioning/dashboards/kraalzibar.json
+++ b/docker/grafana/provisioning/dashboards/kraalzibar.json
@@ -1,0 +1,184 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Request Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(kraalzibar_requests_total[5m])",
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(kraalzibar_requests_success_total[5m])",
+          "legendFormat": "Success",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "title": "Error Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(kraalzibar_requests_error_total[5m])",
+          "legendFormat": "Errors",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Request Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 0
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(kraalzibar_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(kraalzibar_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(kraalzibar_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "title": "Requests by Method",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(kraalzibar_method_requests_total[5m])",
+          "legendFormat": "{{ method }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Schema Cache Hit Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(kraalzibar_schema_cache_hits_total[5m]) / (rate(kraalzibar_schema_cache_hits_total[5m]) + rate(kraalzibar_schema_cache_misses_total[5m]))",
+          "legendFormat": "Schema Cache Hit Rate",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Check Cache Hit Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(kraalzibar_check_cache_hits_total[5m]) / (rate(kraalzibar_check_cache_hits_total[5m]) + rate(kraalzibar_check_cache_misses_total[5m]))",
+          "legendFormat": "Check Cache Hit Rate",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["kraalzibar"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Kraalzibar",
+  "uid": "kraalzibar-overview",
+  "version": 1
+}

--- a/docker/grafana/provisioning/datasources/datasources.yml
+++ b/docker/grafana/provisioning/datasources/datasources.yml
@@ -5,9 +5,18 @@ datasources:
     type: prometheus
     access: proxy
     url: http://prometheus:9090
+    uid: prometheus
     isDefault: true
 
-  - name: Jaeger
-    type: jaeger
+  - name: Tempo
+    type: tempo
     access: proxy
-    url: http://jaeger:16686
+    url: http://tempo:3200
+    uid: tempo
+    jsonData:
+      tracesToMetrics:
+        datasourceUid: prometheus
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true

--- a/docker/otel-collector.yml
+++ b/docker/otel-collector.yml
@@ -1,0 +1,25 @@
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo]

--- a/docker/tempo.yml
+++ b/docker/tempo.yml
@@ -1,0 +1,26 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /var/tempo/generator/wal


### PR DESCRIPTION
## Summary

- Replace Jaeger (all-in-one) with **OTel Collector** (trace pipeline) + **Grafana Tempo** (trace storage) in Docker Compose
- Add pre-built Grafana dashboard with request rate, error rate, latency percentiles, per-method breakdown, and cache hit rate panels
- Configure Tempo datasource in Grafana with traces-to-metrics correlation and node graph support
- No Rust code changes — the server already exports OTLP traces

## Changes

| File | Action |
|------|--------|
| `docker/otel-collector.yml` | **New** — OTel Collector config (OTLP receiver → batch → Tempo exporter) |
| `docker/tempo.yml` | **New** — Tempo config (local storage, OTLP receiver) |
| `docker/docker-compose.yml` | **Edit** — remove Jaeger, add otel-collector + tempo services |
| `docker/grafana/provisioning/datasources/datasources.yml` | **Edit** — replace Jaeger datasource with Tempo |
| `docker/grafana/provisioning/dashboards/dashboards.yml` | **New** — dashboard provider config |
| `docker/grafana/provisioning/dashboards/kraalzibar.json` | **New** — pre-built overview dashboard |
| `README.md` | **Edit** — update Docker Compose services table |

## Test plan

- [ ] `cd docker && docker compose up -d` — all services start healthy
- [ ] Start server, make API calls, verify traces appear in Grafana → Explore → Tempo
- [ ] Verify pre-built dashboard loads and shows metric panels
- [ ] `cargo test --workspace` — all Rust tests still pass (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)