### PR TITLE
fix: make --config flag global so it works after subcommand

### DIFF
--- a/crates/kraalzibar-server/src/cli.rs
+++ b/crates/kraalzibar-server/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 #[derive(Debug, Parser)]
 #[command(name = "kraalzibar-server", version)]
 pub struct Cli {
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     pub config: Option<PathBuf>,
 
     #[command(subcommand)]
@@ -90,6 +90,18 @@ mod tests {
             cli.command,
             Some(Command::CreateApiKey { tenant_name }) if tenant_name == "acme"
         ));
+    }
+
+    #[test]
+    fn cli_config_flag_works_after_subcommand() {
+        let cli = Cli::parse_from([
+            "kraalzibar-server",
+            "serve",
+            "--config",
+            "/etc/kraalzibar.toml",
+        ]);
+        assert_eq!(cli.config, Some(PathBuf::from("/etc/kraalzibar.toml")));
+        assert!(matches!(cli.command, Some(Command::Serve)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- The `--config` flag was only accepted **before** the subcommand (e.g., `kraalzibar-server --config config.toml serve`) because it lacked `global = true`
- The README documents it **after** the subcommand (`kraalzibar-server serve --config config.toml`), which silently failed
- Added `global = true` to the clap arg attribute so `--config` works in either position

## Test plan
- [x] Added `cli_config_flag_works_after_subcommand` test that verifies `--config` after `serve`
- [x] All 162 existing tests pass
- [x] Clippy and fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)