### PR TITLE
chore: release v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "kraalzibar-client"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "kraalzibar-core",
  "kraalzibar-server",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "kraalzibar-core"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "pest",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "kraalzibar-server"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "argon2",
  "axum 0.7.9",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "kraalzibar-storage"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "kraalzibar-core",
  "sqlx",

--- a/crates/kraalzibar-client/Cargo.toml
+++ b/crates/kraalzibar-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kraalzibar-client"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/kraalzibar-core/Cargo.toml
+++ b/crates/kraalzibar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kraalzibar-core"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/kraalzibar-server/Cargo.toml
+++ b/crates/kraalzibar-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kraalzibar-server"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [[bin]]

--- a/crates/kraalzibar-storage/Cargo.toml
+++ b/crates/kraalzibar-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kraalzibar-storage"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kraalzibar/client",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "TypeScript SDK for Kraalzibar authorization server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bump all crate versions from 0.1.0 to 1.0.0 (core, storage, server, client)
- Bump TypeScript SDK version from 0.1.0 to 1.0.0

## Test plan

- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [ ] After merge, tag `v1.0.0` to trigger the Docker Hub publish pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)