### PR TITLE
fix: bound lookup_resources to prevent unbounded table scan

### DIFF
--- a/crates/kraalzibar-core/src/engine/mod.rs
+++ b/crates/kraalzibar-core/src/engine/mod.rs
@@ -33,6 +33,7 @@ pub enum CheckError {
 pub struct EngineConfig {
     pub max_depth: usize,
     pub max_concurrent_branches: usize,
+    pub max_lookup_candidates: usize,
 }
 
 impl Default for EngineConfig {
@@ -40,7 +41,20 @@ impl Default for EngineConfig {
         Self {
             max_depth: 6,
             max_concurrent_branches: 10,
+            max_lookup_candidates: 50_000,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_config_default_max_lookup_candidates() {
+        let config = EngineConfig::default();
+
+        assert_eq!(config.max_lookup_candidates, 50_000);
     }
 }
 

--- a/crates/kraalzibar-server/src/config.rs
+++ b/crates/kraalzibar-server/src/config.rs
@@ -91,6 +91,7 @@ impl std::fmt::Debug for DatabaseConfig {
 pub struct EngineConfigValues {
     pub max_depth: usize,
     pub max_concurrent_branches: usize,
+    pub max_lookup_candidates: usize,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -176,6 +177,7 @@ impl Default for EngineConfigValues {
         Self {
             max_depth: 6,
             max_concurrent_branches: 10,
+            max_lookup_candidates: 50_000,
         }
     }
 }
@@ -281,6 +283,11 @@ impl AppConfig {
         {
             self.engine.max_depth = n;
         }
+        if let Some(v) = env("KRAALZIBAR_ENGINE_MAX_LOOKUP_CANDIDATES")
+            && let Ok(n) = v.parse()
+        {
+            self.engine.max_lookup_candidates = n;
+        }
         if let Some(v) = env("KRAALZIBAR_CACHE_SCHEMA_CAPACITY")
             && let Ok(n) = v.parse()
         {
@@ -381,6 +388,11 @@ impl AppConfig {
                 "engine.max_concurrent_branches must be non-zero".to_string(),
             ));
         }
+        if self.engine.max_lookup_candidates == 0 {
+            return Err(ConfigError::Validation(
+                "engine.max_lookup_candidates must be non-zero".to_string(),
+            ));
+        }
         if self.schema_limits.max_types == 0 {
             return Err(ConfigError::Validation(
                 "schema_limits.max_types must be non-zero".to_string(),
@@ -440,6 +452,7 @@ impl AppConfig {
         kraalzibar_core::engine::EngineConfig {
             max_depth: self.engine.max_depth,
             max_concurrent_branches: self.engine.max_concurrent_branches,
+            max_lookup_candidates: self.engine.max_lookup_candidates,
         }
     }
 
@@ -943,5 +956,49 @@ key_path = "/etc/kraalzibar/tls/server.key"
             matches!(result, Err(ConfigError::Validation(ref msg)) if msg.contains("tls")),
             "expected validation error for partial TLS config: {result:?}"
         );
+    }
+
+    // --- max_lookup_candidates config tests ---
+
+    #[test]
+    fn default_config_has_max_lookup_candidates() {
+        let config = AppConfig::default();
+
+        assert_eq!(config.engine.max_lookup_candidates, 50_000);
+    }
+
+    #[test]
+    fn validation_rejects_zero_max_lookup_candidates() {
+        let mut config = AppConfig::default();
+        config.engine.max_lookup_candidates = 0;
+
+        let result = config.validate();
+        assert!(
+            matches!(result, Err(ConfigError::Validation(ref msg)) if msg.contains("max_lookup_candidates"))
+        );
+    }
+
+    #[test]
+    fn max_lookup_candidates_env_override() {
+        let mut config = AppConfig::default();
+        let env = |key: &str| -> Option<String> {
+            match key {
+                "KRAALZIBAR_ENGINE_MAX_LOOKUP_CANDIDATES" => Some("25000".to_string()),
+                _ => None,
+            }
+        };
+        config.apply_env_overrides_with(env);
+
+        assert_eq!(config.engine.max_lookup_candidates, 25_000);
+    }
+
+    #[test]
+    fn to_engine_config_includes_max_lookup_candidates() {
+        let mut config = AppConfig::default();
+        config.engine.max_lookup_candidates = 10_000;
+
+        let engine_config = config.to_engine_config();
+
+        assert_eq!(engine_config.max_lookup_candidates, 10_000);
     }
 }

--- a/crates/kraalzibar-server/src/error.rs
+++ b/crates/kraalzibar-server/src/error.rs
@@ -21,6 +21,9 @@ pub enum ApiError {
 
     #[error("schema not found")]
     SchemaNotFound,
+
+    #[error("lookup candidate set ({count}) exceeds maximum ({limit}); narrow your query")]
+    TooManyCandidates { count: usize, limit: usize },
 }
 
 fn format_validation_errors(errors: &[ValidationError]) -> String {
@@ -92,5 +95,21 @@ mod tests {
     fn api_error_schema_not_found() {
         let api_err = ApiError::SchemaNotFound;
         assert!(api_err.to_string().contains("schema not found"));
+    }
+
+    #[test]
+    fn api_error_too_many_candidates() {
+        let api_err = ApiError::TooManyCandidates {
+            count: 50_001,
+            limit: 50_000,
+        };
+        let msg = api_err.to_string();
+
+        assert!(msg.contains("50001"), "should contain count: {msg}");
+        assert!(msg.contains("50000"), "should contain limit: {msg}");
+        assert!(
+            msg.contains("narrow your query"),
+            "should contain guidance: {msg}"
+        );
     }
 }

--- a/crates/kraalzibar-server/src/error.rs
+++ b/crates/kraalzibar-server/src/error.rs
@@ -22,8 +22,10 @@ pub enum ApiError {
     #[error("schema not found")]
     SchemaNotFound,
 
-    #[error("lookup candidate set ({count}) exceeds maximum ({limit}); narrow your query")]
-    TooManyCandidates { count: usize, limit: usize },
+    #[error(
+        "lookup candidate set exceeds maximum of {limit}; narrow your query or increase the limit"
+    )]
+    TooManyCandidates { limit: usize },
 }
 
 fn format_validation_errors(errors: &[ValidationError]) -> String {
@@ -99,13 +101,9 @@ mod tests {
 
     #[test]
     fn api_error_too_many_candidates() {
-        let api_err = ApiError::TooManyCandidates {
-            count: 50_001,
-            limit: 50_000,
-        };
+        let api_err = ApiError::TooManyCandidates { limit: 50_000 };
         let msg = api_err.to_string();
 
-        assert!(msg.contains("50001"), "should contain count: {msg}");
         assert!(msg.contains("50000"), "should contain limit: {msg}");
         assert!(
             msg.contains("narrow your query"),

--- a/crates/kraalzibar-server/src/grpc/mod.rs
+++ b/crates/kraalzibar-server/src/grpc/mod.rs
@@ -98,16 +98,13 @@ mod tests {
 
     #[test]
     fn too_many_candidates_maps_to_resource_exhausted() {
-        let err = ApiError::TooManyCandidates {
-            count: 50_001,
-            limit: 50_000,
-        };
+        let err = ApiError::TooManyCandidates { limit: 50_000 };
         let status = api_error_to_status(err);
 
         assert_eq!(status.code(), tonic::Code::ResourceExhausted);
         assert!(
-            status.message().contains("50001"),
-            "expected count in message, got: {}",
+            status.message().contains("50000"),
+            "expected limit in message, got: {}",
             status.message()
         );
     }

--- a/crates/kraalzibar-server/src/grpc/mod.rs
+++ b/crates/kraalzibar-server/src/grpc/mod.rs
@@ -44,6 +44,7 @@ fn api_error_to_status(err: crate::error::ApiError) -> Status {
         ApiError::Parse(_) | ApiError::Validation(_) => Status::invalid_argument(err.to_string()),
         ApiError::BreakingChanges(_) => Status::failed_precondition(err.to_string()),
         ApiError::SchemaNotFound => Status::not_found(err.to_string()),
+        ApiError::TooManyCandidates { .. } => Status::resource_exhausted(err.to_string()),
     }
 }
 
@@ -92,6 +93,22 @@ mod tests {
         assert!(
             !status.message().contains("db connection"),
             "internal details must not leak to client"
+        );
+    }
+
+    #[test]
+    fn too_many_candidates_maps_to_resource_exhausted() {
+        let err = ApiError::TooManyCandidates {
+            count: 50_001,
+            limit: 50_000,
+        };
+        let status = api_error_to_status(err);
+
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+        assert!(
+            status.message().contains("50001"),
+            "expected count in message, got: {}",
+            status.message()
         );
     }
 }

--- a/crates/kraalzibar-server/src/rest/handlers.rs
+++ b/crates/kraalzibar-server/src/rest/handlers.rs
@@ -99,6 +99,9 @@ fn api_error_to_response(err: ApiError) -> ApiResult {
         | ApiError::Storage(kraalzibar_storage::StorageError::SnapshotAhead { .. }) => {
             error_response(StatusCode::BAD_REQUEST, &err.to_string())
         }
+        ApiError::TooManyCandidates { .. } => {
+            error_response(StatusCode::UNPROCESSABLE_ENTITY, &err.to_string())
+        }
         ApiError::Check(CheckError::StorageError(_))
         | ApiError::Storage(kraalzibar_storage::StorageError::Internal(_)) => {
             tracing::error!(error = %err, "internal storage error");
@@ -1006,6 +1009,22 @@ mod tests {
         assert!(
             !msg.contains("db connection"),
             "internal details must not leak to client"
+        );
+    }
+
+    #[test]
+    fn too_many_candidates_returns_422() {
+        let err = ApiError::TooManyCandidates {
+            count: 50_001,
+            limit: 50_000,
+        };
+        let (status, body) = api_error_to_response(err);
+
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        let msg = body.0["error"].as_str().unwrap();
+        assert!(
+            msg.contains("50001"),
+            "expected count in message, got: {msg}"
         );
     }
 

--- a/crates/kraalzibar-server/src/rest/handlers.rs
+++ b/crates/kraalzibar-server/src/rest/handlers.rs
@@ -1014,17 +1014,14 @@ mod tests {
 
     #[test]
     fn too_many_candidates_returns_422() {
-        let err = ApiError::TooManyCandidates {
-            count: 50_001,
-            limit: 50_000,
-        };
+        let err = ApiError::TooManyCandidates { limit: 50_000 };
         let (status, body) = api_error_to_response(err);
 
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         let msg = body.0["error"].as_str().unwrap();
         assert!(
-            msg.contains("50001"),
-            "expected count in message, got: {msg}"
+            msg.contains("50000"),
+            "expected limit in message, got: {msg}"
         );
     }
 

--- a/crates/kraalzibar-server/src/service.rs
+++ b/crates/kraalzibar-server/src/service.rs
@@ -380,9 +380,18 @@ where
         let store = Arc::new(store);
         let snapshot = self.resolve_snapshot(&*store, input.consistency).await?;
 
+        // Fetch one more than the limit to detect overflow without loading the full set
+        let candidate_limit = self.engine_config.max_lookup_candidates;
         let object_ids = store
-            .list_object_ids(&input.resource_type, snapshot, None)
+            .list_object_ids(&input.resource_type, snapshot, Some(candidate_limit + 1))
             .await?;
+
+        if object_ids.len() > candidate_limit {
+            return Err(ApiError::TooManyCandidates {
+                count: object_ids.len(),
+                limit: candidate_limit,
+            });
+        }
 
         let schema = self.load_schema_cached(tenant_id, &*store).await?;
 
@@ -1016,6 +1025,105 @@ mod tests {
             .unwrap();
 
         assert_eq!(output.resource_ids.len(), 2, "should respect limit of 2");
+    }
+
+    fn make_service_with_config(
+        config: EngineConfig,
+    ) -> (AuthzService<InMemoryStoreFactory>, TenantId) {
+        let factory = Arc::new(InMemoryStoreFactory::new());
+        let service = AuthzService::new(Arc::clone(&factory), config, SchemaLimits::default());
+        let tenant_id = TenantId::new(uuid::Uuid::new_v4());
+        (service, tenant_id)
+    }
+
+    #[tokio::test]
+    async fn lookup_resources_rejects_too_many_candidates() {
+        let config = EngineConfig {
+            max_lookup_candidates: 3,
+            ..Default::default()
+        };
+        let (service, tenant_id) = make_service_with_config(config);
+        setup_schema(&service, &tenant_id).await;
+
+        // Write 4 documents — exceeds limit of 3
+        for i in 0..4 {
+            write_tuple(
+                &service,
+                &tenant_id,
+                "document",
+                &format!("doc{i}"),
+                "viewer",
+                "user",
+                "alice",
+            )
+            .await;
+        }
+
+        let result = service
+            .lookup_resources(
+                &tenant_id,
+                LookupResourcesInput {
+                    resource_type: "document".to_string(),
+                    permission: "can_view".to_string(),
+                    subject_type: "user".to_string(),
+                    subject_id: "alice".to_string(),
+                    consistency: Consistency::MinimizeLatency,
+                    limit: None,
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(ApiError::TooManyCandidates { count: 4, limit: 3 })
+            ),
+            "expected TooManyCandidates error, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn lookup_resources_allows_candidates_at_limit() {
+        let config = EngineConfig {
+            max_lookup_candidates: 3,
+            ..Default::default()
+        };
+        let (service, tenant_id) = make_service_with_config(config);
+        setup_schema(&service, &tenant_id).await;
+
+        // Write exactly 3 documents — at the limit, should succeed
+        for i in 0..3 {
+            write_tuple(
+                &service,
+                &tenant_id,
+                "document",
+                &format!("doc{i}"),
+                "viewer",
+                "user",
+                "alice",
+            )
+            .await;
+        }
+
+        let result = service
+            .lookup_resources(
+                &tenant_id,
+                LookupResourcesInput {
+                    resource_type: "document".to_string(),
+                    permission: "can_view".to_string(),
+                    subject_type: "user".to_string(),
+                    subject_id: "alice".to_string(),
+                    consistency: Consistency::MinimizeLatency,
+                    limit: None,
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "expected success at exactly the limit, got: {result:?}"
+        );
+        assert_eq!(result.unwrap().resource_ids.len(), 3);
     }
 
     #[tokio::test]

--- a/crates/kraalzibar-server/src/service.rs
+++ b/crates/kraalzibar-server/src/service.rs
@@ -383,12 +383,15 @@ where
         // Fetch one more than the limit to detect overflow without loading the full set
         let candidate_limit = self.engine_config.max_lookup_candidates;
         let object_ids = store
-            .list_object_ids(&input.resource_type, snapshot, Some(candidate_limit + 1))
+            .list_object_ids(
+                &input.resource_type,
+                snapshot,
+                Some(candidate_limit.saturating_add(1)),
+            )
             .await?;
 
         if object_ids.len() > candidate_limit {
             return Err(ApiError::TooManyCandidates {
-                count: object_ids.len(),
                 limit: candidate_limit,
             });
         }
@@ -1074,10 +1077,7 @@ mod tests {
             .await;
 
         assert!(
-            matches!(
-                result,
-                Err(ApiError::TooManyCandidates { count: 4, limit: 3 })
-            ),
+            matches!(result, Err(ApiError::TooManyCandidates { limit: 3 })),
             "expected TooManyCandidates error, got: {result:?}"
         );
     }


### PR DESCRIPTION
## Summary
- Adds configurable `max_lookup_candidates` limit (default 50,000) to `EngineConfig`
- `lookup_resources` now fetches at most `max_lookup_candidates + 1` object IDs and returns a `TooManyCandidates` error if the candidate set exceeds the limit
- Error maps to HTTP 422 (Unprocessable Entity) for REST and gRPC `ResourceExhausted`
- Configurable via TOML (`engine.max_lookup_candidates`) or env var (`KRAALZIBAR_ENGINE_MAX_LOOKUP_CANDIDATES`)

## Test plan
- [x] `lookup_resources_rejects_too_many_candidates` — verifies error when candidates exceed limit
- [x] `lookup_resources_allows_candidates_at_limit` — verifies success at exactly the limit
- [x] `too_many_candidates_returns_422` — REST error mapping
- [x] `too_many_candidates_maps_to_resource_exhausted` — gRPC error mapping
- [x] `api_error_too_many_candidates` — error message formatting
- [x] `default_config_has_max_lookup_candidates` — default value is 50,000
- [x] `validation_rejects_zero_max_lookup_candidates` — config validation
- [x] `max_lookup_candidates_env_override` — env var override
- [x] `to_engine_config_includes_max_lookup_candidates` — config propagation
- [x] All existing tests continue to pass

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)