### PR TITLE
fix: add gRPC input validation for batch size and identifier length

### DIFF
--- a/crates/kraalzibar-server/src/grpc/conversions.rs
+++ b/crates/kraalzibar-server/src/grpc/conversions.rs
@@ -4,9 +4,16 @@ use kraalzibar_core::tuple::{
 
 use crate::proto::kraalzibar::v1;
 use crate::service::Consistency;
+use crate::validation::validate_identifier;
 
-pub fn proto_object_to_domain(obj: &v1::ObjectReference) -> ObjectRef {
-    ObjectRef::new(&obj.object_type, &obj.object_id)
+use super::validation_err_to_status;
+
+#[allow(clippy::result_large_err)]
+pub fn proto_object_to_domain(obj: &v1::ObjectReference) -> Result<ObjectRef, tonic::Status> {
+    validate_identifier("object_type", &obj.object_type).map_err(validation_err_to_status)?;
+    validate_identifier("object_id", &obj.object_id).map_err(validation_err_to_status)?;
+
+    Ok(ObjectRef::new(&obj.object_type, &obj.object_id))
 }
 
 pub fn domain_object_to_proto(obj: &ObjectRef) -> v1::ObjectReference {
@@ -16,11 +23,19 @@ pub fn domain_object_to_proto(obj: &ObjectRef) -> v1::ObjectReference {
     }
 }
 
-pub fn proto_subject_to_domain(subj: &v1::SubjectReference) -> SubjectRef {
-    match &subj.subject_relation {
+#[allow(clippy::result_large_err)]
+pub fn proto_subject_to_domain(subj: &v1::SubjectReference) -> Result<SubjectRef, tonic::Status> {
+    validate_identifier("subject_type", &subj.subject_type).map_err(validation_err_to_status)?;
+    validate_identifier("subject_id", &subj.subject_id).map_err(validation_err_to_status)?;
+
+    if let Some(ref rel) = subj.subject_relation {
+        validate_identifier("subject_relation", rel).map_err(validation_err_to_status)?;
+    }
+
+    Ok(match &subj.subject_relation {
         Some(rel) => SubjectRef::userset(&subj.subject_type, &subj.subject_id, rel),
         None => SubjectRef::direct(&subj.subject_type, &subj.subject_id),
-    }
+    })
 }
 
 pub fn domain_subject_to_proto(subj: &SubjectRef) -> v1::SubjectReference {
@@ -44,26 +59,52 @@ pub fn proto_relationship_to_write(rel: &v1::Relationship) -> Result<TupleWrite,
     let object = rel
         .object
         .as_ref()
-        .map(proto_object_to_domain)
         .ok_or_else(|| tonic::Status::invalid_argument("relationship object is required"))?;
+    let object = proto_object_to_domain(object)?;
+
     let subject = rel
         .subject
         .as_ref()
-        .map(proto_subject_to_domain)
         .ok_or_else(|| tonic::Status::invalid_argument("relationship subject is required"))?;
+    let subject = proto_subject_to_domain(subject)?;
+
+    validate_identifier("relation", &rel.relation).map_err(validation_err_to_status)?;
 
     Ok(TupleWrite::new(object, &rel.relation, subject))
 }
 
-pub fn proto_filter_to_domain(filter: &v1::RelationshipFilter) -> TupleFilter {
-    TupleFilter {
+#[allow(clippy::result_large_err)]
+pub fn proto_filter_to_domain(
+    filter: &v1::RelationshipFilter,
+) -> Result<TupleFilter, tonic::Status> {
+    if let Some(ref v) = filter.object_type {
+        validate_identifier("object_type", v).map_err(validation_err_to_status)?;
+    }
+
+    if let Some(ref v) = filter.object_id {
+        validate_identifier("object_id", v).map_err(validation_err_to_status)?;
+    }
+
+    if let Some(ref v) = filter.relation {
+        validate_identifier("relation", v).map_err(validation_err_to_status)?;
+    }
+
+    if let Some(ref v) = filter.subject_type {
+        validate_identifier("subject_type", v).map_err(validation_err_to_status)?;
+    }
+
+    if let Some(ref v) = filter.subject_id {
+        validate_identifier("subject_id", v).map_err(validation_err_to_status)?;
+    }
+
+    Ok(TupleFilter {
         object_type: filter.object_type.clone(),
         object_id: filter.object_id.clone(),
         relation: filter.relation.clone(),
         subject_type: filter.subject_type.clone(),
         subject_id: filter.subject_id.clone(),
         subject_relation: None,
-    }
+    })
 }
 
 #[allow(clippy::result_large_err)]
@@ -165,7 +206,7 @@ mod tests {
     fn convert_object_reference_round_trip() {
         let domain = ObjectRef::new("document", "readme");
         let proto = domain_object_to_proto(&domain);
-        let back = proto_object_to_domain(&proto);
+        let back = proto_object_to_domain(&proto).unwrap();
 
         assert_eq!(back.object_type, "document");
         assert_eq!(back.object_id, "readme");
@@ -175,7 +216,7 @@ mod tests {
     fn convert_direct_subject_round_trip() {
         let domain = SubjectRef::direct("user", "alice");
         let proto = domain_subject_to_proto(&domain);
-        let back = proto_subject_to_domain(&proto);
+        let back = proto_subject_to_domain(&proto).unwrap();
 
         assert_eq!(back.subject_type, "user");
         assert_eq!(back.subject_id, "alice");
@@ -186,7 +227,7 @@ mod tests {
     fn convert_userset_subject_round_trip() {
         let domain = SubjectRef::userset("group", "eng", "member");
         let proto = domain_subject_to_proto(&domain);
-        let back = proto_subject_to_domain(&proto);
+        let back = proto_subject_to_domain(&proto).unwrap();
 
         assert_eq!(back.subject_type, "group");
         assert_eq!(back.subject_id, "eng");
@@ -217,7 +258,7 @@ mod tests {
             subject_type: None,
             subject_id: None,
         };
-        let domain = proto_filter_to_domain(&proto);
+        let domain = proto_filter_to_domain(&proto).unwrap();
 
         assert_eq!(domain.object_type.as_deref(), Some("document"));
         assert!(domain.object_id.is_none());
@@ -277,5 +318,128 @@ mod tests {
 
         let none = snapshot_to_zed_token(None);
         assert!(none.is_none());
+    }
+
+    #[test]
+    fn proto_object_rejects_empty_object_type() {
+        let proto = v1::ObjectReference {
+            object_type: String::new(),
+            object_id: "readme".to_string(),
+        };
+        let result = proto_object_to_domain(&proto);
+
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(
+            status.message().contains("object_type"),
+            "expected field name in error, got: {}",
+            status.message()
+        );
+    }
+
+    #[test]
+    fn proto_object_rejects_too_long_object_id() {
+        let long = "a".repeat(257);
+        let proto = v1::ObjectReference {
+            object_type: "document".to_string(),
+            object_id: long,
+        };
+        let result = proto_object_to_domain(&proto);
+
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(
+            status.message().contains("object_id"),
+            "expected field name in error, got: {}",
+            status.message()
+        );
+    }
+
+    #[test]
+    fn proto_subject_rejects_empty_subject_type() {
+        let proto = v1::SubjectReference {
+            subject_type: String::new(),
+            subject_id: "alice".to_string(),
+            subject_relation: None,
+        };
+        let result = proto_subject_to_domain(&proto);
+
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn proto_subject_rejects_too_long_subject_relation() {
+        let long = "a".repeat(257);
+        let proto = v1::SubjectReference {
+            subject_type: "user".to_string(),
+            subject_id: "alice".to_string(),
+            subject_relation: Some(long),
+        };
+        let result = proto_subject_to_domain(&proto);
+
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn proto_relationship_to_write_validates_relation() {
+        let proto = v1::Relationship {
+            object: Some(v1::ObjectReference {
+                object_type: "document".to_string(),
+                object_id: "readme".to_string(),
+            }),
+            relation: String::new(),
+            subject: Some(v1::SubjectReference {
+                subject_type: "user".to_string(),
+                subject_id: "alice".to_string(),
+                subject_relation: None,
+            }),
+        };
+        let result = proto_relationship_to_write(&proto);
+
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(
+            status.message().contains("relation"),
+            "expected 'relation' in error, got: {}",
+            status.message()
+        );
+    }
+
+    #[test]
+    fn proto_filter_rejects_too_long_object_type() {
+        let long = "a".repeat(257);
+        let proto = v1::RelationshipFilter {
+            object_type: Some(long),
+            object_id: None,
+            relation: None,
+            subject_type: None,
+            subject_id: None,
+        };
+        let result = proto_filter_to_domain(&proto);
+
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn proto_filter_accepts_none_fields() {
+        let proto = v1::RelationshipFilter {
+            object_type: None,
+            object_id: None,
+            relation: None,
+            subject_type: None,
+            subject_id: None,
+        };
+        let result = proto_filter_to_domain(&proto);
+
+        assert!(result.is_ok());
     }
 }

--- a/crates/kraalzibar-server/src/grpc/mod.rs
+++ b/crates/kraalzibar-server/src/grpc/mod.rs
@@ -10,6 +10,12 @@ pub use schema_service::SchemaServiceImpl;
 use kraalzibar_core::tuple::TenantId;
 use tonic::{Request, Status};
 
+use crate::validation;
+
+fn validation_err_to_status(err: validation::ValidationError) -> Status {
+    Status::invalid_argument(err.to_string())
+}
+
 #[allow(clippy::result_large_err)]
 fn extract_tenant_id<T>(request: &Request<T>) -> Result<TenantId, Status> {
     request

--- a/crates/kraalzibar-server/src/grpc/permission_service.rs
+++ b/crates/kraalzibar-server/src/grpc/permission_service.rs
@@ -12,7 +12,9 @@ use crate::service::{
     LookupSubjectsInput,
 };
 
-use super::{conversions, extract_tenant_id};
+use crate::validation::validate_identifier;
+
+use super::{conversions, extract_tenant_id, validation_err_to_status};
 
 pub struct PermissionServiceImpl<F: StoreFactory> {
     service: Arc<AuthzService<F>>,
@@ -53,6 +55,14 @@ where
         let subject = req
             .subject
             .ok_or_else(|| Status::invalid_argument("subject is required"))?;
+
+        validate_identifier("object_type", &resource.object_type)
+            .map_err(validation_err_to_status)?;
+        validate_identifier("object_id", &resource.object_id).map_err(validation_err_to_status)?;
+        validate_identifier("permission", &req.permission).map_err(validation_err_to_status)?;
+        validate_identifier("subject_type", &subject.subject_type)
+            .map_err(validation_err_to_status)?;
+        validate_identifier("subject_id", &subject.subject_id).map_err(validation_err_to_status)?;
 
         let input = CheckPermissionInput {
             object_type: resource.object_type,
@@ -97,6 +107,11 @@ where
             .resource
             .ok_or_else(|| Status::invalid_argument("resource is required"))?;
 
+        validate_identifier("object_type", &resource.object_type)
+            .map_err(validation_err_to_status)?;
+        validate_identifier("object_id", &resource.object_id).map_err(validation_err_to_status)?;
+        validate_identifier("permission", &req.permission).map_err(validation_err_to_status)?;
+
         let input = ExpandPermissionInput {
             object_type: resource.object_type,
             object_id: resource.object_id,
@@ -133,6 +148,13 @@ where
         let subject = req
             .subject
             .ok_or_else(|| Status::invalid_argument("subject is required"))?;
+
+        validate_identifier("resource_type", &req.resource_type)
+            .map_err(validation_err_to_status)?;
+        validate_identifier("permission", &req.permission).map_err(validation_err_to_status)?;
+        validate_identifier("subject_type", &subject.subject_type)
+            .map_err(validation_err_to_status)?;
+        validate_identifier("subject_id", &subject.subject_id).map_err(validation_err_to_status)?;
 
         let input = LookupResourcesInput {
             resource_type: req.resource_type,
@@ -185,6 +207,12 @@ where
         let resource = req
             .resource
             .ok_or_else(|| Status::invalid_argument("resource is required"))?;
+
+        validate_identifier("object_type", &resource.object_type)
+            .map_err(validation_err_to_status)?;
+        validate_identifier("object_id", &resource.object_id).map_err(validation_err_to_status)?;
+        validate_identifier("permission", &req.permission).map_err(validation_err_to_status)?;
+        validate_identifier("subject_type", &req.subject_type).map_err(validation_err_to_status)?;
 
         let input = LookupSubjectsInput {
             object_type: resource.object_type,

--- a/crates/kraalzibar-server/src/grpc/relationship_service.rs
+++ b/crates/kraalzibar-server/src/grpc/relationship_service.rs
@@ -2,13 +2,16 @@ use std::sync::Arc;
 
 use tonic::{Request, Response, Status};
 
+use kraalzibar_core::tuple::TupleFilter;
 use kraalzibar_storage::traits::{RelationshipStore, SchemaStore, StoreFactory};
 
 use crate::metrics::Metrics;
 use crate::proto::kraalzibar::v1::{self, relationship_service_server::RelationshipService};
 use crate::service::AuthzService;
 
-use super::{conversions, extract_tenant_id};
+use crate::validation::validate_batch_size;
+
+use super::{conversions, extract_tenant_id, validation_err_to_status};
 
 pub struct RelationshipServiceImpl<F: StoreFactory> {
     service: Arc<AuthzService<F>>,
@@ -43,6 +46,8 @@ where
         let tenant_id = extract_tenant_id(&request)?;
         let req = request.into_inner();
 
+        validate_batch_size(req.updates.len()).map_err(validation_err_to_status)?;
+
         let mut writes = Vec::new();
         let mut deletes = Vec::new();
 
@@ -68,7 +73,7 @@ where
                             subject_type: rel.subject.as_ref().map(|s| s.subject_type.clone()),
                             subject_id: rel.subject.as_ref().map(|s| s.subject_id.clone()),
                         },
-                    ));
+                    )?);
                 }
                 v1::relationship_update::Operation::Unspecified => {
                     return Err(Status::invalid_argument("operation must be specified"));
@@ -99,11 +104,10 @@ where
         let tenant_id = extract_tenant_id(&request)?;
         let req = request.into_inner();
 
-        let filter = req
-            .filter
-            .as_ref()
-            .map(conversions::proto_filter_to_domain)
-            .unwrap_or_default();
+        let filter = match req.filter.as_ref() {
+            Some(f) => conversions::proto_filter_to_domain(f)?,
+            None => TupleFilter::default(),
+        };
 
         let consistency = conversions::proto_consistency_to_domain(req.consistency.as_ref())?;
 

--- a/crates/kraalzibar-server/src/lib.rs
+++ b/crates/kraalzibar-server/src/lib.rs
@@ -14,3 +14,4 @@ pub mod rest;
 pub mod service;
 pub mod telemetry;
 pub mod tls;
+pub mod validation;

--- a/crates/kraalzibar-server/src/rest/handlers.rs
+++ b/crates/kraalzibar-server/src/rest/handlers.rs
@@ -16,12 +16,11 @@ use crate::service::{
     CheckPermissionInput, Consistency, ExpandPermissionInput, LookupResourcesInput,
     LookupSubjectsInput,
 };
+use crate::validation::MAX_BATCH_SIZE;
 
 use super::AppState;
 use super::types::*;
 
-const MAX_BATCH_SIZE: usize = 1000;
-const MAX_IDENTIFIER_LENGTH: usize = 256;
 const DEFAULT_READ_LIMIT: usize = 1000;
 
 type ApiResult = (StatusCode, Json<serde_json::Value>);
@@ -44,19 +43,8 @@ fn error_response(status: StatusCode, msg: &str) -> ApiResult {
 }
 
 fn validate_identifier(field: &str, value: &str) -> Result<(), ApiResult> {
-    if value.is_empty() {
-        return Err(error_response(
-            StatusCode::BAD_REQUEST,
-            &format!("{field} must not be empty"),
-        ));
-    }
-    if value.len() > MAX_IDENTIFIER_LENGTH {
-        return Err(error_response(
-            StatusCode::BAD_REQUEST,
-            &format!("{field} exceeds maximum length of {MAX_IDENTIFIER_LENGTH}"),
-        ));
-    }
-    Ok(())
+    crate::validation::validate_identifier(field, value)
+        .map_err(|e| error_response(StatusCode::BAD_REQUEST, &e.to_string()))
 }
 
 fn resolve_consistency(c: Option<&ConsistencyRequest>) -> Result<Consistency, ApiResult> {

--- a/crates/kraalzibar-server/src/rest/handlers.rs
+++ b/crates/kraalzibar-server/src/rest/handlers.rs
@@ -340,6 +340,12 @@ where
             return e;
         }
 
+        if let Some(ref rel) = update.subject_relation
+            && let Err(e) = validate_identifier("subject_relation", rel)
+        {
+            return e;
+        }
+
         let object = ObjectRef::new(&update.resource_type, &update.resource_id);
         let subject = match &update.subject_relation {
             Some(rel) => SubjectRef::userset(&update.subject_type, &update.subject_id, rel),
@@ -786,6 +792,30 @@ mod tests {
             .await;
 
         response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn write_relationships_rejects_empty_subject_relation() {
+        let server = make_test_server();
+
+        let response = server
+            .post("/v1/relationships/write")
+            .json(&json!({
+                "updates": [{
+                    "operation": "touch",
+                    "resource_type": "document",
+                    "resource_id": "readme",
+                    "relation": "viewer",
+                    "subject_type": "user",
+                    "subject_id": "alice",
+                    "subject_relation": ""
+                }]
+            }))
+            .await;
+
+        response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = response.json();
+        assert!(body["error"].as_str().unwrap().contains("subject_relation"));
     }
 
     #[tokio::test]

--- a/crates/kraalzibar-server/src/rest/handlers.rs
+++ b/crates/kraalzibar-server/src/rest/handlers.rs
@@ -389,17 +389,44 @@ where
     F: StoreFactory + 'static,
     F::Store: RelationshipStore + SchemaStore,
 {
-    let filter = req
-        .filter
-        .map(|f| TupleFilter {
-            object_type: f.resource_type,
-            object_id: f.resource_id,
-            relation: f.relation,
-            subject_type: f.subject_type,
-            subject_id: f.subject_id,
-            subject_relation: None,
-        })
-        .unwrap_or_default();
+    let filter = match req.filter {
+        Some(f) => {
+            if let Some(ref v) = f.resource_type
+                && let Err(e) = validate_identifier("resource_type", v)
+            {
+                return e;
+            }
+            if let Some(ref v) = f.resource_id
+                && let Err(e) = validate_identifier("resource_id", v)
+            {
+                return e;
+            }
+            if let Some(ref v) = f.relation
+                && let Err(e) = validate_identifier("relation", v)
+            {
+                return e;
+            }
+            if let Some(ref v) = f.subject_type
+                && let Err(e) = validate_identifier("subject_type", v)
+            {
+                return e;
+            }
+            if let Some(ref v) = f.subject_id
+                && let Err(e) = validate_identifier("subject_id", v)
+            {
+                return e;
+            }
+            TupleFilter {
+                object_type: f.resource_type,
+                object_id: f.resource_id,
+                relation: f.relation,
+                subject_type: f.subject_type,
+                subject_id: f.subject_id,
+                subject_relation: None,
+            }
+        }
+        None => TupleFilter::default(),
+    };
 
     let consistency = match resolve_consistency(req.consistency.as_ref()) {
         Ok(c) => c,
@@ -994,6 +1021,25 @@ mod tests {
         assert!(
             !msg.contains("db connection"),
             "internal details must not leak to client"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_relationships_rejects_empty_filter_field() {
+        let server = make_test_server();
+
+        let response = server
+            .post("/v1/relationships/read")
+            .json(&json!({
+                "filter": {"resource_type": ""}
+            }))
+            .await;
+
+        response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = response.json();
+        assert!(
+            body["error"].as_str().unwrap().contains("resource_type"),
+            "expected error about resource_type, got: {body}"
         );
     }
 

--- a/crates/kraalzibar-server/src/validation.rs
+++ b/crates/kraalzibar-server/src/validation.rs
@@ -1,0 +1,124 @@
+pub const MAX_BATCH_SIZE: usize = 1000;
+pub const MAX_IDENTIFIER_LENGTH: usize = 256;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+    #[error("{field} must not be empty")]
+    EmptyIdentifier { field: String },
+
+    #[error("{field} exceeds maximum length of {MAX_IDENTIFIER_LENGTH}")]
+    IdentifierTooLong { field: String },
+
+    #[error("batch size {size} exceeds maximum of {MAX_BATCH_SIZE}")]
+    BatchTooLarge { size: usize },
+}
+
+pub fn validate_identifier(field: &str, value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() {
+        return Err(ValidationError::EmptyIdentifier {
+            field: field.to_string(),
+        });
+    }
+
+    if value.len() > MAX_IDENTIFIER_LENGTH {
+        return Err(ValidationError::IdentifierTooLong {
+            field: field.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+pub fn validate_batch_size(size: usize) -> Result<(), ValidationError> {
+    if size > MAX_BATCH_SIZE {
+        return Err(ValidationError::BatchTooLarge { size });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_identifier_accepts_valid_string() {
+        let result = validate_identifier("object_type", "document");
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_identifier_rejects_empty_string() {
+        let result = validate_identifier("object_type", "");
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("object_type"),
+            "expected field name in error, got: {msg}"
+        );
+        assert!(
+            msg.contains("must not be empty"),
+            "expected empty message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_identifier_rejects_too_long_string() {
+        let long = "a".repeat(MAX_IDENTIFIER_LENGTH + 1);
+        let result = validate_identifier("object_id", &long);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("object_id"),
+            "expected field name in error, got: {msg}"
+        );
+        assert!(
+            msg.contains("maximum length"),
+            "expected length message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_identifier_accepts_max_length_string() {
+        let exact = "a".repeat(MAX_IDENTIFIER_LENGTH);
+        let result = validate_identifier("relation", &exact);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_batch_size_accepts_within_limit() {
+        let result = validate_batch_size(MAX_BATCH_SIZE);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_batch_size_rejects_over_limit() {
+        let result = validate_batch_size(MAX_BATCH_SIZE + 1);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("batch size"),
+            "expected batch size in error, got: {msg}"
+        );
+        assert!(
+            msg.contains("1001"),
+            "expected size value in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_batch_size_accepts_zero() {
+        let result = validate_batch_size(0);
+
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `validation` module with `validate_identifier` and `validate_batch_size` functions, replacing duplicated constants/logic in REST handlers
- Add identifier validation (non-empty, max 256 chars) to all gRPC conversion functions (`proto_object_to_domain`, `proto_subject_to_domain`, `proto_filter_to_domain`, `proto_relationship_to_write`)
- Add identifier validation to all gRPC permission service handlers (`check_permission`, `expand_permission_tree`, `lookup_resources`, `lookup_subjects`)
- Add batch size validation (max 1000) to gRPC `write_relationships` handler

## Test plan
- [x] 7 unit tests for the shared validation module (empty, too-long, boundary, batch size)
- [x] 7 new tests for gRPC conversion validation (empty object_type, too-long object_id, empty subject_type, too-long subject_relation, empty relation, too-long filter field, None filter fields)
- [x] All 27 existing REST handler tests still pass (validates backward compatibility)
- [x] All 18 conversion tests pass (existing round-trip + new validation)
- [x] `cargo clippy` zero warnings, `cargo fmt --check` clean

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)