### PR TITLE
fix: suppress clippy::result_large_err on gRPC auth interceptor

### DIFF
--- a/crates/kraalzibar-server/src/main.rs
+++ b/crates/kraalzibar-server/src/main.rs
@@ -305,6 +305,7 @@ where
 
     let grpc_auth = {
         let auth = auth_state.clone();
+        #[allow(clippy::result_large_err)]
         move |req: tonic::Request<()>| -> Result<tonic::Request<()>, tonic::Status> {
             kraalzibar_server::middleware::grpc_auth_interceptor(&auth, req)
         }


### PR DESCRIPTION
## Summary

- Fixes CI lint failure across all open PRs
- Rust 1.94 stable clippy flags the gRPC auth interceptor closure for returning `Result<_, tonic::Status>` (176 bytes)
- This is a known tonic API limitation — the interceptor signature is fixed by the framework
- Suppressed with `#[allow(clippy::result_large_err)]` on the closure

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)