### PR TITLE
fix: add API key rotation, revocation, and expiry (SEC-28)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arc-swap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +207,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +323,28 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -484,6 +537,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -494,14 +549,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -571,6 +634,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -843,6 +915,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1066,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,8 +1198,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1115,9 +1211,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1362,13 +1460,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.0",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
  "tokio",
@@ -1547,6 +1648,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1703,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1630,7 +1757,9 @@ version = "1.0.0"
 dependencies = [
  "argon2",
  "axum 0.7.9",
+ "axum-server",
  "axum-test",
+ "chrono",
  "clap",
  "kraalzibar-core",
  "kraalzibar-storage",
@@ -1640,6 +1769,10 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.13.5",
  "rand 0.8.5",
+ "rcgen",
+ "reqwest",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sqlx",
@@ -1648,6 +1781,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "toml",
  "tonic 0.12.3",
@@ -1740,6 +1874,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -2091,6 +2231,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,6 +2539,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,6 +2688,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,6 +2766,43 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "reserve-port"
@@ -2633,6 +2888,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2669,6 +2925,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2678,6 +2935,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3258,6 +3516,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3567,8 +3828,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.5",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -3680,6 +3943,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3982,6 +4263,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4394,6 +4689,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/kraalzibar-server/Cargo.toml
+++ b/crates/kraalzibar-server/Cargo.toml
@@ -12,11 +12,12 @@ kraalzibar-core = { path = "../kraalzibar-core" }
 kraalzibar-storage = { path = "../kraalzibar-storage" }
 argon2 = "0.5"
 axum = { version = "0.7", features = ["json"] }
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 prost = "0.13"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
 serde_json = "1"
 moka = { version = "0.12", features = ["future"] }
 thiserror = "2"

--- a/crates/kraalzibar-server/src/api_key_repository.rs
+++ b/crates/kraalzibar-server/src/api_key_repository.rs
@@ -18,7 +18,10 @@ impl ApiKeyRepository {
         key_id: &str,
     ) -> Result<Option<ApiKeyRecord>, sqlx::Error> {
         let row = sqlx::query_as::<_, ApiKeyRow>(
-            "SELECT key_id, key_hash, tenant_id, (revoked_at IS NOT NULL) as revoked FROM api_keys WHERE key_id = $1",
+            "SELECT key_id, key_hash, tenant_id, \
+             (revoked_at IS NOT NULL) as revoked, \
+             (expires_at IS NOT NULL AND expires_at < now()) as expired \
+             FROM api_keys WHERE key_id = $1",
         )
         .bind(key_id)
         .fetch_optional(&self.pool)
@@ -29,6 +32,7 @@ impl ApiKeyRepository {
             key_hash: r.key_hash,
             tenant_id: TenantId::new(r.tenant_id),
             revoked: r.revoked,
+            expired: r.expired,
         }))
     }
 
@@ -46,6 +50,60 @@ impl ApiKeyRepository {
             .await?;
         Ok(())
     }
+
+    pub async fn insert_with_expiry(
+        &self,
+        tenant_id: &TenantId,
+        key_id: &str,
+        key_hash: &str,
+        expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO api_keys (tenant_id, key_id, key_hash, expires_at) \
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(tenant_id.as_uuid())
+        .bind(key_id)
+        .bind(key_hash)
+        .bind(expires_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn revoke_by_key_id(&self, key_id: &str) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            "UPDATE api_keys SET revoked_at = now() \
+             WHERE key_id = $1 AND revoked_at IS NULL",
+        )
+        .bind(key_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn list_for_tenant(
+        &self,
+        tenant_id: &TenantId,
+    ) -> Result<Vec<ApiKeyInfo>, sqlx::Error> {
+        let rows = sqlx::query_as::<_, ApiKeyInfoRow>(
+            "SELECT key_id, created_at, revoked_at, expires_at \
+             FROM api_keys WHERE tenant_id = $1 ORDER BY created_at",
+        )
+        .bind(tenant_id.as_uuid())
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| ApiKeyInfo {
+                key_id: r.key_id,
+                created_at: r.created_at,
+                revoked_at: r.revoked_at,
+                expires_at: r.expires_at,
+            })
+            .collect())
+    }
 }
 
 #[derive(sqlx::FromRow)]
@@ -54,6 +112,23 @@ struct ApiKeyRow {
     key_hash: String,
     tenant_id: uuid::Uuid,
     revoked: bool,
+    expired: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApiKeyInfo {
+    pub key_id: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub revoked_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(sqlx::FromRow)]
+struct ApiKeyInfoRow {
+    key_id: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+    revoked_at: Option<chrono::DateTime<chrono::Utc>>,
+    expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[cfg(test)]
@@ -113,6 +188,134 @@ mod tests {
 
         let record = repo.lookup_by_key_id("revokedkey").await.unwrap().unwrap();
         assert!(record.revoked);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn expired_key_returns_expired_true() {
+        let pool = test_pool().await;
+        let repo = ApiKeyRepository::new(pool.clone());
+
+        let tenant_id = TenantId::new(uuid::Uuid::new_v4());
+        provision_test_tenant(&pool, &tenant_id, "test-expired").await;
+
+        let key_hash = crate::auth::hash_secret("secret3").unwrap();
+        let past = chrono::Utc::now() - chrono::Duration::hours(1);
+        repo.insert_with_expiry(&tenant_id, "expiredkey", &key_hash, past)
+            .await
+            .unwrap();
+
+        let record = repo.lookup_by_key_id("expiredkey").await.unwrap().unwrap();
+        assert!(record.expired);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn non_expired_key_returns_expired_false() {
+        let pool = test_pool().await;
+        let repo = ApiKeyRepository::new(pool.clone());
+
+        let tenant_id = TenantId::new(uuid::Uuid::new_v4());
+        provision_test_tenant(&pool, &tenant_id, "test-not-expired").await;
+
+        let key_hash = crate::auth::hash_secret("secret4").unwrap();
+        let future = chrono::Utc::now() + chrono::Duration::hours(24);
+        repo.insert_with_expiry(&tenant_id, "futurekey", &key_hash, future)
+            .await
+            .unwrap();
+
+        let record = repo.lookup_by_key_id("futurekey").await.unwrap().unwrap();
+        assert!(!record.expired);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn revoke_by_key_id_marks_key_revoked() {
+        let pool = test_pool().await;
+        let repo = ApiKeyRepository::new(pool.clone());
+
+        let tenant_id = TenantId::new(uuid::Uuid::new_v4());
+        provision_test_tenant(&pool, &tenant_id, "test-revoke-cmd").await;
+
+        let key_hash = crate::auth::hash_secret("secret5").unwrap();
+        repo.insert(&tenant_id, "revoketest1", &key_hash)
+            .await
+            .unwrap();
+
+        let revoked = repo.revoke_by_key_id("revoketest1").await.unwrap();
+        assert!(revoked);
+
+        let record = repo.lookup_by_key_id("revoketest1").await.unwrap().unwrap();
+        assert!(record.revoked);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn revoke_unknown_key_returns_false() {
+        let pool = test_pool().await;
+        let repo = ApiKeyRepository::new(pool);
+
+        let revoked = repo.revoke_by_key_id("nonexistentkey").await.unwrap();
+        assert!(!revoked);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn revoke_already_revoked_key_returns_false() {
+        let pool = test_pool().await;
+        let repo = ApiKeyRepository::new(pool.clone());
+
+        let tenant_id = TenantId::new(uuid::Uuid::new_v4());
+        provision_test_tenant(&pool, &tenant_id, "test-double-revoke").await;
+
+        let key_hash = crate::auth::hash_secret("secret6").unwrap();
+        repo.insert(&tenant_id, "doublerevoke", &key_hash)
+            .await
+            .unwrap();
+
+        let first = repo.revoke_by_key_id("doublerevoke").await.unwrap();
+        assert!(first);
+
+        let second = repo.revoke_by_key_id("doublerevoke").await.unwrap();
+        assert!(!second);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn list_for_tenant_returns_all_keys() {
+        let pool = test_pool().await;
+        let repo = ApiKeyRepository::new(pool.clone());
+
+        let tenant_id = TenantId::new(uuid::Uuid::new_v4());
+        provision_test_tenant(&pool, &tenant_id, "test-list-keys").await;
+
+        let key_hash = crate::auth::hash_secret("s1").unwrap();
+        repo.insert(&tenant_id, "listkey1", &key_hash)
+            .await
+            .unwrap();
+        repo.insert(&tenant_id, "listkey2", &key_hash)
+            .await
+            .unwrap();
+
+        let keys = repo.list_for_tenant(&tenant_id).await.unwrap();
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys[0].key_id, "listkey1");
+        assert_eq!(keys[1].key_id, "listkey2");
+        assert!(keys[0].revoked_at.is_none());
+        assert!(keys[0].expires_at.is_none());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn list_for_tenant_with_no_keys_returns_empty() {
+        let pool = test_pool().await;
+        let repo = ApiKeyRepository::new(pool.clone());
+
+        let tenant_id = TenantId::new(uuid::Uuid::new_v4());
+        provision_test_tenant(&pool, &tenant_id, "test-list-empty").await;
+
+        let keys = repo.list_for_tenant(&tenant_id).await.unwrap();
+        assert!(keys.is_empty());
     }
 
     async fn test_pool() -> PgPool {

--- a/crates/kraalzibar-server/src/auth.rs
+++ b/crates/kraalzibar-server/src/auth.rs
@@ -18,6 +18,9 @@ pub enum AuthError {
     #[error("api key has been revoked")]
     RevokedKey,
 
+    #[error("api key has expired")]
+    ExpiredKey,
+
     #[error("internal authentication error: {0}")]
     Internal(String),
 }
@@ -28,6 +31,7 @@ pub struct ApiKeyRecord {
     pub key_hash: String,
     pub tenant_id: TenantId,
     pub revoked: bool,
+    pub expired: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -114,6 +118,11 @@ pub fn authenticate(
         return Err(AuthError::RevokedKey);
     }
 
+    if record.expired {
+        audit::audit_auth_failure("api key expired", Some(key_id));
+        return Err(AuthError::ExpiredKey);
+    }
+
     let valid = verify_secret(secret, &record.key_hash)?;
     if !valid {
         audit::audit_auth_failure("invalid secret", Some(key_id));
@@ -182,6 +191,7 @@ mod tests {
             key_hash,
             tenant_id: tenant_id.clone(),
             revoked: false,
+            expired: false,
         };
 
         let ctx = authenticate(&full_key, |_| Some(record)).unwrap();
@@ -199,6 +209,7 @@ mod tests {
             key_hash,
             tenant_id: TenantId::new(uuid::Uuid::new_v4()),
             revoked: true,
+            expired: false,
         };
 
         let result = authenticate(&full_key, |_| Some(record));
@@ -221,9 +232,28 @@ mod tests {
             key_hash,
             tenant_id: TenantId::new(uuid::Uuid::new_v4()),
             revoked: false,
+            expired: false,
         };
 
         let result = authenticate("kraalzibar_testid_wrong_secret", |_| Some(record));
         assert!(matches!(result, Err(AuthError::UnknownKey)));
+    }
+
+    #[test]
+    fn authenticate_rejects_expired_key() {
+        let (full_key, secret) = generate_api_key();
+        let (key_id, _) = parse_api_key(&full_key).unwrap();
+        let key_hash = hash_secret(&secret).unwrap();
+
+        let record = ApiKeyRecord {
+            key_id: key_id.to_string(),
+            key_hash,
+            tenant_id: TenantId::new(uuid::Uuid::new_v4()),
+            revoked: false,
+            expired: true,
+        };
+
+        let result = authenticate(&full_key, |_| Some(record));
+        assert!(matches!(result, Err(AuthError::ExpiredKey)));
     }
 }

--- a/crates/kraalzibar-server/src/cli.rs
+++ b/crates/kraalzibar-server/src/cli.rs
@@ -31,6 +31,18 @@ pub enum Command {
         #[arg(long)]
         yes: bool,
     },
+    RevokeApiKey {
+        #[arg(long)]
+        key_id: String,
+    },
+    ListApiKeys {
+        #[arg(long)]
+        tenant_name: String,
+    },
+    RotateApiKey {
+        #[arg(long)]
+        key_id: String,
+    },
 }
 
 #[cfg(test)]
@@ -146,5 +158,47 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
+    }
+
+    #[test]
+    fn cli_parses_revoke_api_key() {
+        let cli = Cli::parse_from([
+            "kraalzibar-server",
+            "revoke-api-key",
+            "--key-id",
+            "abc12345",
+        ]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::RevokeApiKey { key_id }) if key_id == "abc12345"
+        ));
+    }
+
+    #[test]
+    fn cli_parses_list_api_keys() {
+        let cli = Cli::parse_from([
+            "kraalzibar-server",
+            "list-api-keys",
+            "--tenant-name",
+            "acme",
+        ]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::ListApiKeys { tenant_name }) if tenant_name == "acme"
+        ));
+    }
+
+    #[test]
+    fn cli_parses_rotate_api_key() {
+        let cli = Cli::parse_from([
+            "kraalzibar-server",
+            "rotate-api-key",
+            "--key-id",
+            "abc12345",
+        ]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::RotateApiKey { key_id }) if key_id == "abc12345"
+        ));
     }
 }

--- a/crates/kraalzibar-server/src/main.rs
+++ b/crates/kraalzibar-server/src/main.rs
@@ -88,6 +88,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(Command::PurgeRelationships { tenant_name, yes }) => {
             run_purge_relationships(&config, &tenant_name, yes).await
         }
+        Some(Command::RevokeApiKey { key_id }) => run_revoke_api_key(&config, &key_id).await,
+        Some(Command::ListApiKeys { tenant_name }) => {
+            run_list_api_keys(&config, &tenant_name).await
+        }
+        Some(Command::RotateApiKey { key_id }) => run_rotate_api_key(&config, &key_id).await,
         Some(Command::Serve) | None => run_serve(config).await,
     }
 }
@@ -194,6 +199,120 @@ async fn run_purge_relationships(
         "Purged {deleted} relationship(s) for tenant '{tenant_name}'. Transaction sequence reset.",
     );
 
+    Ok(())
+}
+
+async fn run_revoke_api_key(
+    config: &AppConfig,
+    key_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    config.database.require_configured()?;
+    let pool = sqlx::PgPool::connect(&config.database.url).await?;
+    kraalzibar_storage::postgres::migrations::run_shared_migrations(&pool).await?;
+
+    let repo = ApiKeyRepository::new(pool);
+    let revoked = repo.revoke_by_key_id(key_id).await?;
+
+    if revoked {
+        println!("API key '{key_id}' has been revoked.");
+    } else {
+        eprintln!("Error: API key '{key_id}' not found or already revoked");
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+async fn run_list_api_keys(
+    config: &AppConfig,
+    tenant_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    config.database.require_configured()?;
+    let pool = sqlx::PgPool::connect(&config.database.url).await?;
+    kraalzibar_storage::postgres::migrations::run_shared_migrations(&pool).await?;
+
+    let row = sqlx::query_as::<_, (uuid::Uuid,)>("SELECT id FROM tenants WHERE name = $1")
+        .bind(tenant_name)
+        .fetch_optional(&pool)
+        .await?;
+
+    let tenant_uuid = match row {
+        Some((id,)) => id,
+        None => {
+            eprintln!("Error: tenant '{tenant_name}' not found");
+            std::process::exit(1);
+        }
+    };
+
+    let repo = ApiKeyRepository::new(pool);
+    let keys = repo.list_for_tenant(&TenantId::new(tenant_uuid)).await?;
+
+    if keys.is_empty() {
+        println!("No API keys found for tenant '{tenant_name}'.");
+    } else {
+        println!("API keys for tenant '{tenant_name}':");
+        println!(
+            "{:<12} {:<24} {:<24} {:<24}",
+            "KEY_ID", "CREATED_AT", "REVOKED_AT", "EXPIRES_AT"
+        );
+        for key in &keys {
+            let revoked = key
+                .revoked_at
+                .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let expires = key
+                .expires_at
+                .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
+                .unwrap_or_else(|| "-".to_string());
+            println!(
+                "{:<12} {:<24} {:<24} {:<24}",
+                key.key_id,
+                key.created_at.format("%Y-%m-%d %H:%M:%S"),
+                revoked,
+                expires,
+            );
+        }
+        println!("\nTotal: {} key(s)", keys.len());
+    }
+    Ok(())
+}
+
+async fn run_rotate_api_key(
+    config: &AppConfig,
+    old_key_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    config.database.require_configured()?;
+    let pool = sqlx::PgPool::connect(&config.database.url).await?;
+    kraalzibar_storage::postgres::migrations::run_shared_migrations(&pool).await?;
+
+    let old_row = sqlx::query_as::<_, (uuid::Uuid,)>(
+        "SELECT tenant_id FROM api_keys WHERE key_id = $1 AND revoked_at IS NULL",
+    )
+    .bind(old_key_id)
+    .fetch_optional(&pool)
+    .await?;
+
+    let tenant_uuid = match old_row {
+        Some((id,)) => id,
+        None => {
+            eprintln!("Error: API key '{old_key_id}' not found or already revoked");
+            std::process::exit(1);
+        }
+    };
+
+    let (full_key, secret) = auth::generate_api_key();
+    let (new_key_id, _) = auth::parse_api_key(&full_key).expect("generated key should parse");
+    let key_hash = auth::hash_secret(&secret)?;
+
+    let repo = ApiKeyRepository::new(pool);
+    let tenant_id = TenantId::new(tenant_uuid);
+    repo.insert(&tenant_id, new_key_id, &key_hash).await?;
+    repo.revoke_by_key_id(old_key_id).await?;
+
+    println!("API key rotated successfully");
+    println!("  Old key '{old_key_id}' has been revoked");
+    println!("  New API Key: {full_key}");
+    println!();
+    println!("Store this key securely — it will not be shown again.");
     Ok(())
 }
 

--- a/crates/kraalzibar-server/src/main.rs
+++ b/crates/kraalzibar-server/src/main.rs
@@ -285,7 +285,7 @@ async fn run_rotate_api_key(
     kraalzibar_storage::postgres::migrations::run_shared_migrations(&pool).await?;
 
     let old_row = sqlx::query_as::<_, (uuid::Uuid,)>(
-        "SELECT tenant_id FROM api_keys WHERE key_id = $1 AND revoked_at IS NULL",
+        "SELECT tenant_id FROM api_keys WHERE key_id = $1 AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > now())",
     )
     .bind(old_key_id)
     .fetch_optional(&pool)
@@ -294,7 +294,7 @@ async fn run_rotate_api_key(
     let tenant_uuid = match old_row {
         Some((id,)) => id,
         None => {
-            eprintln!("Error: API key '{old_key_id}' not found or already revoked");
+            eprintln!("Error: API key '{old_key_id}' not found, already revoked, or expired");
             std::process::exit(1);
         }
     };
@@ -303,10 +303,20 @@ async fn run_rotate_api_key(
     let (new_key_id, _) = auth::parse_api_key(&full_key).expect("generated key should parse");
     let key_hash = auth::hash_secret(&secret)?;
 
-    let repo = ApiKeyRepository::new(pool);
     let tenant_id = TenantId::new(tenant_uuid);
-    repo.insert(&tenant_id, new_key_id, &key_hash).await?;
-    repo.revoke_by_key_id(old_key_id).await?;
+
+    let mut tx = pool.begin().await?;
+    sqlx::query("INSERT INTO api_keys (tenant_id, key_id, key_hash) VALUES ((SELECT id FROM tenants WHERE id = $1), $2, $3)")
+        .bind(tenant_id.as_uuid())
+        .bind(new_key_id)
+        .bind(&key_hash)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("UPDATE api_keys SET revoked_at = now() WHERE key_id = $1 AND revoked_at IS NULL")
+        .bind(old_key_id)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
 
     println!("API key rotated successfully");
     println!("  Old key '{old_key_id}' has been revoked");

--- a/crates/kraalzibar-server/src/middleware/auth.rs
+++ b/crates/kraalzibar-server/src/middleware/auth.rs
@@ -100,6 +100,9 @@ pub async fn rest_auth_middleware(
         Err(auth::AuthError::RevokedKey) => {
             error_json(StatusCode::UNAUTHORIZED, "api key has been revoked")
         }
+        Err(auth::AuthError::ExpiredKey) => {
+            error_json(StatusCode::UNAUTHORIZED, "api key has expired")
+        }
         Err(_) => error_json(StatusCode::UNAUTHORIZED, "invalid api key"),
     }
 }
@@ -150,6 +153,9 @@ pub fn grpc_auth_interceptor(
         }
         Err(auth::AuthError::RevokedKey) => {
             Err(tonic::Status::unauthenticated("api key has been revoked"))
+        }
+        Err(auth::AuthError::ExpiredKey) => {
+            Err(tonic::Status::unauthenticated("api key has expired"))
         }
         Err(_) => Err(tonic::Status::unauthenticated("invalid api key")),
     }

--- a/crates/kraalzibar-storage/src/postgres/migrations.rs
+++ b/crates/kraalzibar-storage/src/postgres/migrations.rs
@@ -43,6 +43,14 @@ pub async fn run_shared_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    sqlx::query(
+        r#"
+        ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Add `expires_at TIMESTAMPTZ` column to `api_keys` table via migration
- Add `ExpiredKey` variant to `AuthError`, check expiration during authentication
- Add `revoke_by_key_id()`, `list_for_tenant()`, `insert_with_expiry()` to `ApiKeyRepository`
- Add CLI commands: `revoke-api-key`, `list-api-keys`, `rotate-api-key`
- `rotate-api-key` creates new key and revokes old atomically

Closes #28

## Test plan
- [x] Unit test: `authenticate_rejects_expired_key`
- [x] CLI parsing tests for new subcommands
- [x] Integration tests (ignored, require PG): expired/non-expired lookup, revoke, list
- [x] All non-ignored tests pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)