### PR TITLE
fix: bound expand tree branching factor (SEC-30)

### DIFF
--- a/crates/kraalzibar-core/src/engine/expand.rs
+++ b/crates/kraalzibar-core/src/engine/expand.rs
@@ -169,6 +169,11 @@ impl<T: TupleReader> ExpandEngine<T> {
             };
 
             let tuples = self.reader.read_tuples(&filter, ctx.snapshot).await?;
+            let limit = self.config.max_expand_results;
+
+            if tuples.len() > limit {
+                return Err(CheckError::TooManyResults(tuples.len(), limit));
+            }
 
             let mut subjects = Vec::new();
             for tuple in &tuples {
@@ -183,6 +188,11 @@ impl<T: TupleReader> ExpandEngine<T> {
                         .reader
                         .read_tuples(&userset_filter, ctx.snapshot)
                         .await?;
+
+                    if userset_tuples.len() > limit {
+                        return Err(CheckError::TooManyResults(userset_tuples.len(), limit));
+                    }
+
                     for ut in &userset_tuples {
                         subjects.push(ExpandTree::Leaf {
                             subject: ut.subject.clone(),
@@ -223,6 +233,11 @@ impl<T: TupleReader> ExpandEngine<T> {
         };
 
         let tuples = self.reader.read_tuples(&filter, ctx.snapshot).await?;
+        let limit = self.config.max_expand_results;
+
+        if tuples.len() > limit {
+            return Err(CheckError::TooManyResults(tuples.len(), limit));
+        }
 
         let mut children = Vec::new();
         for tuple in &tuples {
@@ -628,6 +643,174 @@ mod tests {
             }
             other => panic!("expected This node, got: {other:?}"),
         }
+    }
+
+    fn make_expand_engine_with_config(
+        schema: Schema,
+        tuples: Vec<Tuple>,
+        config: EngineConfig,
+    ) -> ExpandEngine<TestStore> {
+        ExpandEngine::new(Arc::new(TestStore::new(tuples)), Arc::new(schema), config)
+    }
+
+    #[tokio::test]
+    async fn expand_rejects_too_many_direct_tuples() {
+        let schema = Schema {
+            types: vec![TypeDefinition {
+                name: "document".to_string(),
+                relations: vec![RelationDef {
+                    name: "viewer".to_string(),
+                    subject_types: vec![],
+                }],
+                permissions: vec![PermissionDef {
+                    name: "view".to_string(),
+                    rule: RewriteRule::This("viewer".to_string()),
+                }],
+            }],
+        };
+
+        let limit = 5;
+        let tuples: Vec<Tuple> = (0..limit + 1)
+            .map(|i| {
+                Tuple::new(
+                    ObjectRef::new("document", "readme"),
+                    "viewer",
+                    SubjectRef::direct("user", &format!("user_{i}")),
+                )
+            })
+            .collect();
+
+        let config = EngineConfig {
+            max_expand_results: limit,
+            ..Default::default()
+        };
+        let engine = make_expand_engine_with_config(schema, tuples, config);
+
+        let request = ExpandRequest {
+            object_type: "document".to_string(),
+            object_id: "readme".to_string(),
+            permission: "view".to_string(),
+            snapshot: None,
+        };
+
+        let err = engine.expand(&request).await.unwrap_err();
+        assert!(
+            matches!(err, CheckError::TooManyResults(count, max) if count == limit + 1 && max == limit)
+        );
+    }
+
+    #[tokio::test]
+    async fn expand_rejects_too_many_arrow_tuples() {
+        let schema = Schema {
+            types: vec![
+                TypeDefinition {
+                    name: "folder".to_string(),
+                    relations: vec![RelationDef {
+                        name: "viewer".to_string(),
+                        subject_types: vec![],
+                    }],
+                    permissions: vec![PermissionDef {
+                        name: "view".to_string(),
+                        rule: RewriteRule::This("viewer".to_string()),
+                    }],
+                },
+                TypeDefinition {
+                    name: "document".to_string(),
+                    relations: vec![RelationDef {
+                        name: "parent".to_string(),
+                        subject_types: vec![],
+                    }],
+                    permissions: vec![PermissionDef {
+                        name: "view".to_string(),
+                        rule: RewriteRule::Arrow("parent".to_string(), "view".to_string()),
+                    }],
+                },
+            ],
+        };
+
+        let limit = 3;
+        let tuples: Vec<Tuple> = (0..limit + 1)
+            .map(|i| {
+                Tuple::new(
+                    ObjectRef::new("document", "readme"),
+                    "parent",
+                    SubjectRef::direct("folder", &format!("folder_{i}")),
+                )
+            })
+            .collect();
+
+        let config = EngineConfig {
+            max_expand_results: limit,
+            ..Default::default()
+        };
+        let engine = make_expand_engine_with_config(schema, tuples, config);
+
+        let request = ExpandRequest {
+            object_type: "document".to_string(),
+            object_id: "readme".to_string(),
+            permission: "view".to_string(),
+            snapshot: None,
+        };
+
+        let err = engine.expand(&request).await.unwrap_err();
+        assert!(matches!(err, CheckError::TooManyResults(_, _)));
+    }
+
+    #[tokio::test]
+    async fn expand_rejects_too_many_userset_tuples() {
+        let schema = Schema {
+            types: vec![
+                TypeDefinition {
+                    name: "group".to_string(),
+                    relations: vec![RelationDef {
+                        name: "member".to_string(),
+                        subject_types: vec![],
+                    }],
+                    permissions: vec![],
+                },
+                TypeDefinition {
+                    name: "document".to_string(),
+                    relations: vec![RelationDef {
+                        name: "viewer".to_string(),
+                        subject_types: vec![],
+                    }],
+                    permissions: vec![PermissionDef {
+                        name: "view".to_string(),
+                        rule: RewriteRule::This("viewer".to_string()),
+                    }],
+                },
+            ],
+        };
+
+        let limit = 3;
+        let mut tuples = vec![Tuple::new(
+            ObjectRef::new("document", "readme"),
+            "viewer",
+            SubjectRef::userset("group", "eng", "member"),
+        )];
+        for i in 0..limit + 1 {
+            tuples.push(Tuple::new(
+                ObjectRef::new("group", "eng"),
+                "member",
+                SubjectRef::direct("user", &format!("user_{i}")),
+            ));
+        }
+
+        let config = EngineConfig {
+            max_expand_results: limit,
+            ..Default::default()
+        };
+        let engine = make_expand_engine_with_config(schema, tuples, config);
+
+        let request = ExpandRequest {
+            object_type: "document".to_string(),
+            object_id: "readme".to_string(),
+            permission: "view".to_string(),
+            snapshot: None,
+        };
+
+        let err = engine.expand(&request).await.unwrap_err();
+        assert!(matches!(err, CheckError::TooManyResults(_, _)));
     }
 
     #[tokio::test]

--- a/crates/kraalzibar-core/src/engine/mod.rs
+++ b/crates/kraalzibar-core/src/engine/mod.rs
@@ -25,6 +25,9 @@ pub enum CheckError {
     #[error("max depth exceeded: {0}")]
     MaxDepthExceeded(usize),
 
+    #[error("too many results: expand produced {0} tuples, limit is {1}")]
+    TooManyResults(usize, usize),
+
     #[error("storage error: {0}")]
     StorageError(String),
 }
@@ -33,6 +36,7 @@ pub enum CheckError {
 pub struct EngineConfig {
     pub max_depth: usize,
     pub max_concurrent_branches: usize,
+    pub max_expand_results: usize,
 }
 
 impl Default for EngineConfig {
@@ -40,6 +44,7 @@ impl Default for EngineConfig {
         Self {
             max_depth: 6,
             max_concurrent_branches: 10,
+            max_expand_results: 10_000,
         }
     }
 }

--- a/crates/kraalzibar-server/src/config.rs
+++ b/crates/kraalzibar-server/src/config.rs
@@ -91,6 +91,7 @@ impl std::fmt::Debug for DatabaseConfig {
 pub struct EngineConfigValues {
     pub max_depth: usize,
     pub max_concurrent_branches: usize,
+    pub max_expand_results: usize,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -176,6 +177,7 @@ impl Default for EngineConfigValues {
         Self {
             max_depth: 6,
             max_concurrent_branches: 10,
+            max_expand_results: 10_000,
         }
     }
 }
@@ -281,6 +283,11 @@ impl AppConfig {
         {
             self.engine.max_depth = n;
         }
+        if let Some(v) = env("KRAALZIBAR_ENGINE_MAX_EXPAND_RESULTS")
+            && let Ok(n) = v.parse()
+        {
+            self.engine.max_expand_results = n;
+        }
         if let Some(v) = env("KRAALZIBAR_CACHE_SCHEMA_CAPACITY")
             && let Ok(n) = v.parse()
         {
@@ -376,6 +383,11 @@ impl AppConfig {
                 ));
             }
         }
+        if self.engine.max_expand_results == 0 {
+            return Err(ConfigError::Validation(
+                "engine.max_expand_results must be non-zero".to_string(),
+            ));
+        }
         if self.engine.max_concurrent_branches == 0 {
             return Err(ConfigError::Validation(
                 "engine.max_concurrent_branches must be non-zero".to_string(),
@@ -440,6 +452,7 @@ impl AppConfig {
         kraalzibar_core::engine::EngineConfig {
             max_depth: self.engine.max_depth,
             max_concurrent_branches: self.engine.max_concurrent_branches,
+            max_expand_results: self.engine.max_expand_results,
         }
     }
 
@@ -559,6 +572,46 @@ port = 9090
         assert!(
             matches!(result, Err(ConfigError::Validation(ref msg)) if msg.contains("max_depth"))
         );
+    }
+
+    #[test]
+    fn validation_rejects_zero_max_expand_results() {
+        let mut config = AppConfig::default();
+        config.engine.max_expand_results = 0;
+
+        let result = config.validate();
+        assert!(
+            matches!(result, Err(ConfigError::Validation(ref msg)) if msg.contains("max_expand_results"))
+        );
+    }
+
+    #[test]
+    fn default_config_includes_max_expand_results() {
+        let config = AppConfig::default();
+        assert_eq!(config.engine.max_expand_results, 10_000);
+    }
+
+    #[test]
+    fn env_override_max_expand_results() {
+        let mut config = AppConfig::default();
+        let env = |key: &str| -> Option<String> {
+            match key {
+                "KRAALZIBAR_ENGINE_MAX_EXPAND_RESULTS" => Some("5000".to_string()),
+                _ => None,
+            }
+        };
+        config.apply_env_overrides_with(env);
+
+        assert_eq!(config.engine.max_expand_results, 5000);
+    }
+
+    #[test]
+    fn to_engine_config_includes_max_expand_results() {
+        let mut config = AppConfig::default();
+        config.engine.max_expand_results = 7500;
+
+        let engine_config = config.to_engine_config();
+        assert_eq!(engine_config.max_expand_results, 7500);
     }
 
     #[test]

--- a/crates/kraalzibar-server/src/grpc/mod.rs
+++ b/crates/kraalzibar-server/src/grpc/mod.rs
@@ -31,7 +31,8 @@ fn api_error_to_status(err: crate::error::ApiError) -> Status {
         }
         ApiError::Check(CheckError::MaxDepthExceeded(_))
         | ApiError::Check(CheckError::TooManyResults(_, _)) => {
-            Status::resource_exhausted(err.to_string())
+            tracing::warn!(error = %err, "resource exhausted");
+            Status::resource_exhausted("too many results; narrow your query")
         }
         ApiError::Storage(kraalzibar_storage::StorageError::EmptyDeleteFilter)
         | ApiError::Storage(kraalzibar_storage::StorageError::SnapshotAhead { .. }) => {
@@ -94,6 +95,11 @@ mod tests {
         assert!(
             status.message().contains("too many results"),
             "expected 'too many results' in message, got: {}",
+            status.message()
+        );
+        assert!(
+            !status.message().contains("10000"),
+            "internal limit must not leak to client, got: {}",
             status.message()
         );
     }

--- a/crates/kraalzibar-server/src/grpc/mod.rs
+++ b/crates/kraalzibar-server/src/grpc/mod.rs
@@ -29,7 +29,8 @@ fn api_error_to_status(err: crate::error::ApiError) -> Status {
         | ApiError::Check(CheckError::RelationNotFound { .. }) => {
             Status::not_found(err.to_string())
         }
-        ApiError::Check(CheckError::MaxDepthExceeded(_)) => {
+        ApiError::Check(CheckError::MaxDepthExceeded(_))
+        | ApiError::Check(CheckError::TooManyResults(_, _)) => {
             Status::resource_exhausted(err.to_string())
         }
         ApiError::Storage(kraalzibar_storage::StorageError::EmptyDeleteFilter)
@@ -78,6 +79,21 @@ mod tests {
         assert!(
             status.message().contains("ahead"),
             "expected 'ahead' in message, got: {}",
+            status.message()
+        );
+    }
+
+    #[test]
+    fn too_many_results_maps_to_resource_exhausted() {
+        let err = ApiError::Check(kraalzibar_core::engine::CheckError::TooManyResults(
+            10001, 10000,
+        ));
+        let status = api_error_to_status(err);
+
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+        assert!(
+            status.message().contains("too many results"),
+            "expected 'too many results' in message, got: {}",
             status.message()
         );
     }

--- a/crates/kraalzibar-server/src/rest/handlers.rs
+++ b/crates/kraalzibar-server/src/rest/handlers.rs
@@ -88,7 +88,11 @@ fn api_error_to_response(err: ApiError) -> ApiResult {
         | ApiError::SchemaNotFound => error_response(StatusCode::NOT_FOUND, &err.to_string()),
         ApiError::Check(CheckError::MaxDepthExceeded(_))
         | ApiError::Check(CheckError::TooManyResults(_, _)) => {
-            error_response(StatusCode::UNPROCESSABLE_ENTITY, &err.to_string())
+            tracing::warn!(error = %err, "resource exhausted");
+            error_response(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "too many results; narrow your query",
+            )
         }
         ApiError::Parse(_) | ApiError::Validation(_) => {
             error_response(StatusCode::BAD_REQUEST, &err.to_string())
@@ -977,6 +981,10 @@ mod tests {
         assert!(
             msg.contains("too many results"),
             "expected 'too many results' in message, got: {msg}"
+        );
+        assert!(
+            !msg.contains("10000"),
+            "internal limit must not leak to client, got: {msg}"
         );
     }
 

--- a/crates/kraalzibar-server/src/rest/handlers.rs
+++ b/crates/kraalzibar-server/src/rest/handlers.rs
@@ -86,7 +86,8 @@ fn api_error_to_response(err: ApiError) -> ApiResult {
         | ApiError::Check(CheckError::PermissionNotFound { .. })
         | ApiError::Check(CheckError::RelationNotFound { .. })
         | ApiError::SchemaNotFound => error_response(StatusCode::NOT_FOUND, &err.to_string()),
-        ApiError::Check(CheckError::MaxDepthExceeded(_)) => {
+        ApiError::Check(CheckError::MaxDepthExceeded(_))
+        | ApiError::Check(CheckError::TooManyResults(_, _)) => {
             error_response(StatusCode::UNPROCESSABLE_ENTITY, &err.to_string())
         }
         ApiError::Parse(_) | ApiError::Validation(_) => {
@@ -961,6 +962,21 @@ mod tests {
         assert!(
             body.get("read_at").is_none(),
             "read_relationships without consistency should omit read_at: {body}"
+        );
+    }
+
+    #[test]
+    fn too_many_results_returns_422() {
+        let err = ApiError::Check(kraalzibar_core::engine::CheckError::TooManyResults(
+            10001, 10000,
+        ));
+        let (status, body) = api_error_to_response(err);
+
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        let msg = body.0["error"].as_str().unwrap();
+        assert!(
+            msg.contains("too many results"),
+            "expected 'too many results' in message, got: {msg}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Add `max_expand_results` field to `EngineConfig` (default: 10,000)
- Add `CheckError::TooManyResults` variant
- Enforce limit after all `read_tuples` calls in expand engine
- Wire through `AppConfig` with env var `KRAALZIBAR_ENGINE_MAX_EXPAND_RESULTS`
- Map to `Status::resource_exhausted` (gRPC) and HTTP 422 (REST)

Closes #30

## Test plan
- [x] 3 expand engine tests for limit enforcement
- [x] 4 config tests for new field
- [x] 1 gRPC error mapping test
- [x] 1 REST error mapping test
- [x] All 186 workspace tests pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)