### PR TITLE
fix: add response size limit to TypeScript SDK

### DIFF
--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -42,6 +42,7 @@ export type ClientOptions = {
   target: string;
   apiKey?: string;
   timeout?: number;
+  maxResponseSize?: number;
   fetch?: typeof globalThis.fetch;
 };
 
@@ -55,6 +56,7 @@ export const createClient = (options: ClientOptions): KraalzibarClient => {
       target: options.target,
       apiKey: options.apiKey,
       timeout: options.timeout,
+      maxResponseSize: options.maxResponseSize,
     },
     options.fetch,
   );

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,6 +1,7 @@
 export { createClient } from "./client.js";
 export type { KraalzibarClient, ClientOptions } from "./client.js";
 export { KraalzibarError } from "./error.js";
+export { DEFAULT_MAX_RESPONSE_SIZE } from "./rest-transport.js";
 export type { ErrorCode } from "./error.js";
 export type {
   CheckPermissionRequest,

--- a/sdks/typescript/src/rest-transport.ts
+++ b/sdks/typescript/src/rest-transport.ts
@@ -1,9 +1,12 @@
 import { KraalzibarError, mapHttpStatus } from "./error.js";
 
+export const DEFAULT_MAX_RESPONSE_SIZE = 10 * 1024 * 1024; // 10 MB
+
 export type RestTransportOptions = {
   target: string;
   apiKey?: string;
   timeout?: number;
+  maxResponseSize?: number;
 };
 
 export type RestTransport = {
@@ -17,6 +20,7 @@ export const createRestTransport = (
 ): RestTransport => {
   const baseUrl = options.target.replace(/\/$/, "");
   const timeout = options.timeout ?? 30_000;
+  const maxResponseSize = options.maxResponseSize ?? DEFAULT_MAX_RESPONSE_SIZE;
 
   const headers = (): Record<string, string> => {
     const h: Record<string, string> = {
@@ -29,8 +33,17 @@ export const createRestTransport = (
   };
 
   const handleResponse = async <T>(response: Response): Promise<T> => {
+    const contentLength = response.headers.get("content-length");
+    if (contentLength && parseInt(contentLength, 10) > maxResponseSize) {
+      throw new KraalzibarError("RESOURCE_EXHAUSTED", "response too large");
+    }
+
     if (response.ok) {
-      return (await response.json()) as T;
+      const text = await response.text();
+      if (text.length > maxResponseSize) {
+        throw new KraalzibarError("RESOURCE_EXHAUSTED", "response too large");
+      }
+      return JSON.parse(text) as T;
     }
 
     let message = response.statusText;

--- a/sdks/typescript/src/rest-transport.ts
+++ b/sdks/typescript/src/rest-transport.ts
@@ -38,17 +38,20 @@ export const createRestTransport = (
       throw new KraalzibarError("RESOURCE_EXHAUSTED", "response too large");
     }
 
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > maxResponseSize) {
+      throw new KraalzibarError("RESOURCE_EXHAUSTED", "response too large");
+    }
+
+    const text = new TextDecoder().decode(buffer);
+
     if (response.ok) {
-      const text = await response.text();
-      if (text.length > maxResponseSize) {
-        throw new KraalzibarError("RESOURCE_EXHAUSTED", "response too large");
-      }
       return JSON.parse(text) as T;
     }
 
     let message = response.statusText;
     try {
-      const body = await response.json();
+      const body = JSON.parse(text);
       if (typeof body === "object" && body !== null && "error" in body) {
         message = String((body as { error: unknown }).error);
       }

--- a/sdks/typescript/tests/client.test.ts
+++ b/sdks/typescript/tests/client.test.ts
@@ -6,6 +6,7 @@ const mockFetch = (
   status: number,
   body: unknown,
   captureRequest?: { url?: string; init?: RequestInit },
+  extraHeaders?: Record<string, string>,
 ) => {
   return vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
     if (captureRequest) {
@@ -15,7 +16,21 @@ const mockFetch = (
     return new Response(JSON.stringify(body), {
       status,
       statusText: status === 200 ? "OK" : "Error",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", ...extraHeaders },
+    });
+  }) as unknown as typeof globalThis.fetch;
+};
+
+const mockFetchWithTextBody = (
+  status: number,
+  text: string,
+  extraHeaders?: Record<string, string>,
+) => {
+  return vi.fn(async () => {
+    return new Response(text, {
+      status,
+      statusText: status === 200 ? "OK" : "Error",
+      headers: { "content-type": "application/json", ...extraHeaders },
     });
   }) as unknown as typeof globalThis.fetch;
 };
@@ -338,5 +353,128 @@ describe("authorization header", () => {
 
     const headers = captured.init?.headers as Record<string, string>;
     expect(headers["authorization"]).toBeUndefined();
+  });
+});
+
+describe("response size limit", () => {
+  it("should reject response when content-length exceeds default limit", async () => {
+    const client = createClient({
+      target: "http://localhost:8080",
+      fetch: mockFetch(200, { allowed: true }, undefined, {
+        "content-length": String(11 * 1024 * 1024),
+      }),
+    });
+
+    await expect(
+      client.checkPermission({
+        resource_type: "doc",
+        resource_id: "1",
+        permission: "view",
+        subject_type: "user",
+        subject_id: "alice",
+      }),
+    ).rejects.toThrow(KraalzibarError);
+
+    try {
+      await client.checkPermission({
+        resource_type: "doc",
+        resource_id: "1",
+        permission: "view",
+        subject_type: "user",
+        subject_id: "alice",
+      });
+    } catch (e) {
+      expect(e).toBeInstanceOf(KraalzibarError);
+      expect((e as KraalzibarError).code).toBe("RESOURCE_EXHAUSTED");
+      expect((e as KraalzibarError).message).toBe("response too large");
+    }
+  });
+
+  it("should reject response when body exceeds default limit", async () => {
+    const largeBody = "x".repeat(11 * 1024 * 1024);
+    const client = createClient({
+      target: "http://localhost:8080",
+      fetch: mockFetchWithTextBody(200, largeBody),
+    });
+
+    await expect(
+      client.checkPermission({
+        resource_type: "doc",
+        resource_id: "1",
+        permission: "view",
+        subject_type: "user",
+        subject_id: "alice",
+      }),
+    ).rejects.toThrow(KraalzibarError);
+
+    try {
+      await client.checkPermission({
+        resource_type: "doc",
+        resource_id: "1",
+        permission: "view",
+        subject_type: "user",
+        subject_id: "alice",
+      });
+    } catch (e) {
+      expect(e).toBeInstanceOf(KraalzibarError);
+      expect((e as KraalzibarError).code).toBe("RESOURCE_EXHAUSTED");
+      expect((e as KraalzibarError).message).toBe("response too large");
+    }
+  });
+
+  it("should allow response within the default limit", async () => {
+    const client = createClient({
+      target: "http://localhost:8080",
+      fetch: mockFetch(200, { allowed: true }, undefined, {
+        "content-length": String(1024),
+      }),
+    });
+
+    const result = await client.checkPermission({
+      resource_type: "doc",
+      resource_id: "1",
+      permission: "view",
+      subject_type: "user",
+      subject_id: "alice",
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("should respect custom maxResponseSize option", async () => {
+    const client = createClient({
+      target: "http://localhost:8080",
+      maxResponseSize: 100,
+      fetch: mockFetch(200, { allowed: true }, undefined, {
+        "content-length": "200",
+      }),
+    });
+
+    await expect(
+      client.checkPermission({
+        resource_type: "doc",
+        resource_id: "1",
+        permission: "view",
+        subject_type: "user",
+        subject_id: "alice",
+      }),
+    ).rejects.toThrow(KraalzibarError);
+  });
+
+  it("should also check content-length on error responses", async () => {
+    const client = createClient({
+      target: "http://localhost:8080",
+      fetch: mockFetch(500, { error: "server error" }, undefined, {
+        "content-length": String(11 * 1024 * 1024),
+      }),
+    });
+
+    try {
+      await client.readSchema();
+    } catch (e) {
+      expect(e).toBeInstanceOf(KraalzibarError);
+      expect((e as KraalzibarError).code).toBe("RESOURCE_EXHAUSTED");
+      expect((e as KraalzibarError).message).toBe("response too large");
+    }
   });
 });

--- a/sdks/typescript/tests/client.test.ts
+++ b/sdks/typescript/tests/client.test.ts
@@ -477,4 +477,20 @@ describe("response size limit", () => {
       expect((e as KraalzibarError).message).toBe("response too large");
     }
   });
+
+  it("should reject large error body without content-length header", async () => {
+    const largeBody = "x".repeat(11 * 1024 * 1024);
+    const client = createClient({
+      target: "http://localhost:8080",
+      fetch: mockFetchWithTextBody(500, largeBody),
+    });
+
+    try {
+      await client.readSchema();
+    } catch (e) {
+      expect(e).toBeInstanceOf(KraalzibarError);
+      expect((e as KraalzibarError).code).toBe("RESOURCE_EXHAUSTED");
+      expect((e as KraalzibarError).message).toBe("response too large");
+    }
+  });
 });


### PR DESCRIPTION
Adds Content-Length header check and body size check in handleResponse to prevent OOM from oversized server responses. Default limit is 10 MB, configurable via maxResponseSize on ClientOptions. Throws KraalzibarError with RESOURCE_EXHAUSTED when exceeded. Closes #38