### PR TITLE
fix: clamp REST read_relationships limit to 10,000

### DIFF
--- a/crates/kraalzibar-server/src/rest/handlers.rs
+++ b/crates/kraalzibar-server/src/rest/handlers.rs
@@ -418,7 +418,7 @@ where
         Err(resp) => return resp,
     };
 
-    let limit = Some(req.limit.unwrap_or(DEFAULT_READ_LIMIT));
+    let limit = Some(req.limit.unwrap_or(DEFAULT_READ_LIMIT).min(10_000));
 
     match state
         .service
@@ -1007,6 +1007,26 @@ mod tests {
             !msg.contains("db connection"),
             "internal details must not leak to client"
         );
+    }
+
+    #[tokio::test]
+    async fn read_relationships_clamps_limit() {
+        let server = make_test_server();
+        write_tuple(&server, "readme", "viewer", "alice").await;
+
+        // Sending a limit far above max should be clamped to 10_000, not cause an error
+        let response = server
+            .post("/v1/relationships/read")
+            .json(&json!({
+                "filter": {"resource_type": "document"},
+                "limit": 99_999
+            }))
+            .await;
+
+        response.assert_status_ok();
+        let body: serde_json::Value = response.json();
+        let rels = body["relationships"].as_array().unwrap();
+        assert_eq!(rels.len(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Clamp the user-provided `limit` in the REST `read_relationships` handler to a maximum of 10,000, matching the existing gRPC handler behavior
- Add test `read_relationships_clamps_limit` verifying the handler accepts and handles an excessive limit gracefully

## Test plan
- [x] New unit test `read_relationships_clamps_limit` sends `limit: 99999` and verifies success
- [x] All existing tests pass (`cargo test -p kraalzibar-server`)
- [x] `cargo clippy` clean, `cargo fmt` clean

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)