### PR TITLE
fix: obfuscate snapshot tokens to prevent info leakage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,3 +307,9 @@ configuration instructions as they become available.
 - **rcgen 0.13 API change**: `CertificateParams::self_signed(&key_pair)`
   returns `Certificate` without a `key_pair` field. The `KeyPair` must be
   kept separately for `serialize_pem()`.
+- **Snapshot token obfuscation**: Tokens are XOR'd with a random server-local
+  key (`OnceLock<u64>`) and hex-encoded before being sent to clients. The
+  `token.rs` module in `kraalzibar-server` handles encode/decode. The client
+  SDK uses `OpaqueToken(String)` instead of `SnapshotToken(u64)` to treat
+  tokens as opaque. Go and TypeScript SDKs already treated tokens as strings
+  so they needed no changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,9 +307,11 @@ configuration instructions as they become available.
 - **rcgen 0.13 API change**: `CertificateParams::self_signed(&key_pair)`
   returns `Certificate` without a `key_pair` field. The `KeyPair` must be
   kept separately for `serialize_pem()`.
-- **Snapshot token obfuscation**: Tokens are XOR'd with a random server-local
-  key (`OnceLock<u64>`) and hex-encoded before being sent to clients. The
-  `token.rs` module in `kraalzibar-server` handles encode/decode. The client
-  SDK uses `OpaqueToken(String)` instead of `SnapshotToken(u64)` to treat
-  tokens as opaque. Go and TypeScript SDKs already treated tokens as strings
-  so they needed no changes.
+- **Snapshot token obfuscation**: Tokens are obfuscated with a bijective
+  wrapping multiply-add scheme using a random server-local key pair
+  (`OnceLock<(u64, u64)>` — odd multiplier + addend) and hex-encoded before
+  being sent to clients. The `token.rs` module in `kraalzibar-server` handles
+  encode/decode with `mod_inverse` for deobfuscation. The client SDK uses
+  `OpaqueToken(String)` instead of `SnapshotToken(u64)` to treat tokens as
+  opaque. Go and TypeScript SDKs already treated tokens as strings so they
+  needed no changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arc-swap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +207,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +323,28 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -484,6 +537,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -492,6 +547,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -571,6 +632,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -843,6 +913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1064,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,8 +1196,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1115,9 +1209,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1362,13 +1458,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.0",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
  "tokio",
@@ -1547,6 +1646,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1701,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1630,6 +1755,7 @@ version = "1.0.0"
 dependencies = [
  "argon2",
  "axum 0.7.9",
+ "axum-server",
  "axum-test",
  "clap",
  "kraalzibar-core",
@@ -1640,6 +1766,10 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.13.5",
  "rand 0.8.5",
+ "rcgen",
+ "reqwest",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sqlx",
@@ -1648,6 +1778,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "toml",
  "tonic 0.12.3",
@@ -1740,6 +1871,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -2091,6 +2228,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,6 +2536,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,6 +2685,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,6 +2763,43 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "reserve-port"
@@ -2633,6 +2885,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2669,6 +2922,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2678,6 +2932,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3258,6 +3513,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3567,8 +3825,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.5",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -3680,6 +3940,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3982,6 +4260,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4394,6 +4686,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/kraalzibar-client/src/client.rs
+++ b/crates/kraalzibar-client/src/client.rs
@@ -1,9 +1,9 @@
-use kraalzibar_core::tuple::{ObjectRef, SnapshotToken, SubjectRef, TupleFilter};
+use kraalzibar_core::tuple::{ObjectRef, SubjectRef, TupleFilter};
 use tokio_stream::StreamExt;
 use tonic::transport::Channel;
 
 use crate::config::ClientOptions;
-use crate::conversions::{self, Consistency};
+use crate::conversions::{self, Consistency, OpaqueToken};
 use crate::error::ClientError;
 use crate::interceptor::ApiKeyInterceptor;
 use crate::proto::kraalzibar::v1::{
@@ -71,7 +71,7 @@ impl KraalzibarClient {
         let checked_at = response
             .checked_at
             .as_ref()
-            .and_then(conversions::zed_token_to_snapshot);
+            .and_then(conversions::zed_token_to_opaque);
 
         Ok(CheckPermissionResponse {
             allowed,
@@ -116,7 +116,7 @@ impl KraalzibarClient {
         let written_at = response
             .written_at
             .as_ref()
-            .and_then(conversions::zed_token_to_snapshot);
+            .and_then(conversions::zed_token_to_opaque);
 
         Ok(WriteRelationshipsResponse { written_at })
     }
@@ -232,7 +232,7 @@ impl KraalzibarClient {
         let written_at = response
             .written_at
             .as_ref()
-            .and_then(conversions::zed_token_to_snapshot);
+            .and_then(conversions::zed_token_to_opaque);
 
         Ok(WriteSchemaResponse {
             written_at,
@@ -273,7 +273,7 @@ impl KraalzibarClient {
         let expanded_at = response
             .expanded_at
             .as_ref()
-            .and_then(conversions::zed_token_to_snapshot);
+            .and_then(conversions::zed_token_to_opaque);
 
         Ok(ExpandPermissionTreeResponse {
             expanded_at,
@@ -293,7 +293,7 @@ pub struct CheckPermissionRequest {
 #[derive(Debug, Clone)]
 pub struct CheckPermissionResponse {
     pub allowed: bool,
-    pub checked_at: Option<SnapshotToken>,
+    pub checked_at: Option<OpaqueToken>,
 }
 
 #[derive(Debug, Clone)]
@@ -312,7 +312,7 @@ pub struct RelationshipUpdate {
 
 #[derive(Debug, Clone)]
 pub struct WriteRelationshipsResponse {
-    pub written_at: Option<SnapshotToken>,
+    pub written_at: Option<OpaqueToken>,
 }
 
 #[derive(Debug, Clone)]
@@ -348,7 +348,7 @@ pub struct LookupSubjectsRequest {
 
 #[derive(Debug, Clone)]
 pub struct WriteSchemaResponse {
-    pub written_at: Option<SnapshotToken>,
+    pub written_at: Option<OpaqueToken>,
     pub breaking_changes_overridden: bool,
 }
 
@@ -361,6 +361,6 @@ pub struct ExpandPermissionTreeRequest {
 
 #[derive(Debug, Clone)]
 pub struct ExpandPermissionTreeResponse {
-    pub expanded_at: Option<SnapshotToken>,
+    pub expanded_at: Option<OpaqueToken>,
     pub tree: Option<v1::PermissionExpansionTree>,
 }

--- a/crates/kraalzibar-client/src/conversions.rs
+++ b/crates/kraalzibar-client/src/conversions.rs
@@ -1,6 +1,25 @@
-use kraalzibar_core::tuple::{ObjectRef, SnapshotToken, SubjectRef, TupleFilter};
+use kraalzibar_core::tuple::{ObjectRef, SubjectRef, TupleFilter};
 
 use crate::proto::kraalzibar::v1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpaqueToken(String);
+
+impl OpaqueToken {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self(token.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for OpaqueToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 pub fn domain_object_to_proto(obj: &ObjectRef) -> v1::ObjectReference {
     v1::ObjectReference {
@@ -48,21 +67,25 @@ pub fn consistency_to_proto(consistency: &Consistency) -> v1::Consistency {
         },
         Consistency::AtLeastAsFresh(token) => v1::Consistency {
             requirement: Some(v1::consistency::Requirement::AtLeastAsFresh(v1::ZedToken {
-                token: token.value().to_string(),
+                token: token.as_str().to_string(),
             })),
         },
         Consistency::AtExactSnapshot(token) => v1::Consistency {
             requirement: Some(v1::consistency::Requirement::AtExactSnapshot(
                 v1::ZedToken {
-                    token: token.value().to_string(),
+                    token: token.as_str().to_string(),
                 },
             )),
         },
     }
 }
 
-pub fn zed_token_to_snapshot(token: &v1::ZedToken) -> Option<SnapshotToken> {
-    token.token.parse::<u64>().ok().map(SnapshotToken::new)
+pub fn zed_token_to_opaque(token: &v1::ZedToken) -> Option<OpaqueToken> {
+    if token.token.is_empty() {
+        None
+    } else {
+        Some(OpaqueToken::new(&token.token))
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -70,8 +93,8 @@ pub enum Consistency {
     FullConsistency,
     #[default]
     MinimizeLatency,
-    AtLeastAsFresh(SnapshotToken),
-    AtExactSnapshot(SnapshotToken),
+    AtLeastAsFresh(OpaqueToken),
+    AtExactSnapshot(OpaqueToken),
 }
 
 #[cfg(test)]
@@ -98,10 +121,10 @@ mod tests {
 
     #[test]
     fn consistency_converts_to_proto_at_least_as_fresh() {
-        let proto = consistency_to_proto(&Consistency::AtLeastAsFresh(SnapshotToken::new(42)));
+        let proto = consistency_to_proto(&Consistency::AtLeastAsFresh(OpaqueToken::new("abc123")));
         match proto.requirement {
             Some(v1::consistency::Requirement::AtLeastAsFresh(token)) => {
-                assert_eq!(token.token, "42");
+                assert_eq!(token.token, "abc123");
             }
             _ => panic!("expected AtLeastAsFresh"),
         }
@@ -109,10 +132,10 @@ mod tests {
 
     #[test]
     fn consistency_converts_to_proto_at_exact_snapshot() {
-        let proto = consistency_to_proto(&Consistency::AtExactSnapshot(SnapshotToken::new(99)));
+        let proto = consistency_to_proto(&Consistency::AtExactSnapshot(OpaqueToken::new("def456")));
         match proto.requirement {
             Some(v1::consistency::Requirement::AtExactSnapshot(token)) => {
-                assert_eq!(token.token, "99");
+                assert_eq!(token.token, "def456");
             }
             _ => panic!("expected AtExactSnapshot"),
         }
@@ -171,20 +194,20 @@ mod tests {
     }
 
     #[test]
-    fn zed_token_parses_to_snapshot() {
+    fn zed_token_converts_to_opaque() {
         let token = v1::ZedToken {
-            token: "42".to_string(),
+            token: "abc123def456".to_string(),
         };
-        let snapshot = zed_token_to_snapshot(&token);
-        assert_eq!(snapshot, Some(SnapshotToken::new(42)));
+        let opaque = zed_token_to_opaque(&token);
+        assert_eq!(opaque.as_ref().map(|t| t.as_str()), Some("abc123def456"));
     }
 
     #[test]
-    fn zed_token_invalid_returns_none() {
+    fn zed_token_empty_returns_none() {
         let token = v1::ZedToken {
-            token: "not-a-number".to_string(),
+            token: String::new(),
         };
-        let snapshot = zed_token_to_snapshot(&token);
-        assert!(snapshot.is_none());
+        let opaque = zed_token_to_opaque(&token);
+        assert!(opaque.is_none());
     }
 }

--- a/crates/kraalzibar-client/src/lib.rs
+++ b/crates/kraalzibar-client/src/lib.rs
@@ -12,5 +12,5 @@ pub use client::{
     WriteRelationshipsResponse, WriteSchemaResponse,
 };
 pub use config::ClientOptions;
-pub use conversions::Consistency;
+pub use conversions::{Consistency, OpaqueToken};
 pub use error::ClientError;

--- a/crates/kraalzibar-server/src/error.rs
+++ b/crates/kraalzibar-server/src/error.rs
@@ -21,6 +21,9 @@ pub enum ApiError {
 
     #[error("schema not found")]
     SchemaNotFound,
+
+    #[error("invalid snapshot token format")]
+    InvalidToken,
 }
 
 fn format_validation_errors(errors: &[ValidationError]) -> String {
@@ -92,5 +95,11 @@ mod tests {
     fn api_error_schema_not_found() {
         let api_err = ApiError::SchemaNotFound;
         assert!(api_err.to_string().contains("schema not found"));
+    }
+
+    #[test]
+    fn api_error_invalid_token() {
+        let api_err = ApiError::InvalidToken;
+        assert!(api_err.to_string().contains("invalid snapshot token"));
     }
 }

--- a/crates/kraalzibar-server/src/grpc/conversions.rs
+++ b/crates/kraalzibar-server/src/grpc/conversions.rs
@@ -84,17 +84,14 @@ pub fn proto_consistency_to_domain(
 
 pub fn snapshot_to_zed_token(snapshot: Option<SnapshotToken>) -> Option<v1::ZedToken> {
     snapshot.map(|s| v1::ZedToken {
-        token: s.value().to_string(),
+        token: crate::token::encode_snapshot(s),
     })
 }
 
 #[allow(clippy::result_large_err)]
 fn zed_token_to_snapshot(token: &v1::ZedToken) -> Result<SnapshotToken, tonic::Status> {
-    let value: u64 = token
-        .token
-        .parse()
-        .map_err(|_| tonic::Status::invalid_argument("invalid snapshot token format"))?;
-    Ok(SnapshotToken::new(value))
+    crate::token::decode_snapshot(&token.token)
+        .map_err(|_| tonic::Status::invalid_argument("invalid snapshot token format"))
 }
 
 pub fn domain_expand_tree_to_proto(
@@ -244,9 +241,10 @@ mod tests {
 
     #[test]
     fn convert_consistency_at_least_as_fresh() {
+        let encoded = crate::token::encode_snapshot(SnapshotToken::new(42));
         let proto = v1::Consistency {
             requirement: Some(v1::consistency::Requirement::AtLeastAsFresh(v1::ZedToken {
-                token: "42".to_string(),
+                token: encoded,
             })),
         };
         let domain = proto_consistency_to_domain(Some(&proto)).unwrap();
@@ -273,7 +271,10 @@ mod tests {
     #[test]
     fn convert_snapshot_to_zed_token() {
         let token = snapshot_to_zed_token(Some(SnapshotToken::new(99)));
-        assert_eq!(token.unwrap().token, "99");
+        let encoded = token.unwrap().token;
+        assert_ne!(encoded, "99", "token must not be the raw numeric value");
+        let decoded = crate::token::decode_snapshot(&encoded).unwrap();
+        assert_eq!(decoded, SnapshotToken::new(99));
 
         let none = snapshot_to_zed_token(None);
         assert!(none.is_none());

--- a/crates/kraalzibar-server/src/grpc/mod.rs
+++ b/crates/kraalzibar-server/src/grpc/mod.rs
@@ -44,6 +44,7 @@ fn api_error_to_status(err: crate::error::ApiError) -> Status {
         ApiError::Parse(_) | ApiError::Validation(_) => Status::invalid_argument(err.to_string()),
         ApiError::BreakingChanges(_) => Status::failed_precondition(err.to_string()),
         ApiError::SchemaNotFound => Status::not_found(err.to_string()),
+        ApiError::InvalidToken => Status::invalid_argument(err.to_string()),
     }
 }
 

--- a/crates/kraalzibar-server/src/lib.rs
+++ b/crates/kraalzibar-server/src/lib.rs
@@ -14,3 +14,4 @@ pub mod rest;
 pub mod service;
 pub mod telemetry;
 pub mod tls;
+pub mod token;

--- a/crates/kraalzibar-server/src/rest/handlers.rs
+++ b/crates/kraalzibar-server/src/rest/handlers.rs
@@ -6,9 +6,7 @@ use axum::response::IntoResponse;
 use serde::Serialize;
 
 use kraalzibar_core::engine::ExpandTree;
-use kraalzibar_core::tuple::{
-    ObjectRef, SnapshotToken, SubjectRef, TenantId, TupleFilter, TupleWrite,
-};
+use kraalzibar_core::tuple::{ObjectRef, SubjectRef, TenantId, TupleFilter, TupleWrite};
 use kraalzibar_storage::traits::{RelationshipStore, SchemaStore, StoreFactory};
 
 use crate::error::ApiError;
@@ -63,16 +61,16 @@ fn resolve_consistency(c: Option<&ConsistencyRequest>) -> Result<Consistency, Ap
     match c {
         Some(ConsistencyRequest::Full) => Ok(Consistency::FullConsistency),
         Some(ConsistencyRequest::AtLeastAsFresh { token }) => {
-            let val: u64 = token.parse().map_err(|_| {
+            let snap = crate::token::decode_snapshot(token).map_err(|_| {
                 error_response(StatusCode::BAD_REQUEST, "invalid snapshot token format")
             })?;
-            Ok(Consistency::AtLeastAsFresh(SnapshotToken::new(val)))
+            Ok(Consistency::AtLeastAsFresh(snap))
         }
         Some(ConsistencyRequest::AtExactSnapshot { token }) => {
-            let val: u64 = token.parse().map_err(|_| {
+            let snap = crate::token::decode_snapshot(token).map_err(|_| {
                 error_response(StatusCode::BAD_REQUEST, "invalid snapshot token format")
             })?;
-            Ok(Consistency::AtExactSnapshot(SnapshotToken::new(val)))
+            Ok(Consistency::AtExactSnapshot(snap))
         }
         _ => Ok(Consistency::MinimizeLatency),
     }
@@ -104,6 +102,7 @@ fn api_error_to_response(err: ApiError) -> ApiResult {
             tracing::error!(error = %err, "internal storage error");
             error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
         }
+        ApiError::InvalidToken => error_response(StatusCode::BAD_REQUEST, &err.to_string()),
     }
 }
 
@@ -139,7 +138,7 @@ where
 
     match state.service.check_permission(&tenant_id, input).await {
         Ok(result) => {
-            let checked_at = result.snapshot.map(|s| s.value().to_string());
+            let checked_at = result.snapshot.map(crate::token::encode_snapshot);
             json_response(
                 StatusCode::OK,
                 &CheckPermissionResponse {
@@ -189,7 +188,7 @@ where
                 StatusCode::OK,
                 &ExpandPermissionResponse {
                     tree: tree_json,
-                    expanded_at: output.snapshot.map(|s| s.to_string()),
+                    expanded_at: output.snapshot.map(crate::token::encode_snapshot),
                 },
             )
         }
@@ -265,7 +264,7 @@ where
             StatusCode::OK,
             &LookupResourcesResponse {
                 resource_ids: output.resource_ids,
-                looked_up_at: output.snapshot.map(|s| s.to_string()),
+                looked_up_at: output.snapshot.map(crate::token::encode_snapshot),
             },
         ),
         Err(e) => api_error_to_response(e),
@@ -315,7 +314,7 @@ where
                 StatusCode::OK,
                 &LookupSubjectsResponse {
                     subjects,
-                    looked_up_at: output.snapshot.map(|s| s.to_string()),
+                    looked_up_at: output.snapshot.map(crate::token::encode_snapshot),
                 },
             )
         }
@@ -385,7 +384,7 @@ where
         Ok(token) => json_response(
             StatusCode::OK,
             &WriteRelationshipsResponse {
-                written_at: token.value().to_string(),
+                written_at: crate::token::encode_snapshot(token),
             },
         ),
         Err(e) => api_error_to_response(e),
@@ -442,7 +441,7 @@ where
                 StatusCode::OK,
                 &ReadRelationshipsResponse {
                     relationships,
-                    read_at: output.snapshot.map(|s| s.value().to_string()),
+                    read_at: output.snapshot.map(crate::token::encode_snapshot),
                 },
             )
         }

--- a/crates/kraalzibar-server/src/token.rs
+++ b/crates/kraalzibar-server/src/token.rs
@@ -2,20 +2,62 @@ use kraalzibar_core::tuple::SnapshotToken;
 
 use crate::error::ApiError;
 
-static OBFUSCATION_KEY: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+const ENCODED_TOKEN_LEN: usize = 16;
 
-fn get_key() -> u64 {
-    *OBFUSCATION_KEY.get_or_init(rand::random::<u64>)
+static OBFUSCATION_KEY: std::sync::OnceLock<(u64, u64)> = std::sync::OnceLock::new();
+
+fn get_keys() -> (u64, u64) {
+    *OBFUSCATION_KEY.get_or_init(|| {
+        let mul = rand::random::<u64>() | 1; // ensure odd for invertibility
+        let add = rand::random::<u64>();
+        (mul, add)
+    })
+}
+
+fn obfuscate(value: u64) -> u64 {
+    let (mul, add) = get_keys();
+    value.wrapping_mul(mul).wrapping_add(add)
+}
+
+fn deobfuscate(obfuscated: u64) -> u64 {
+    let (mul, add) = get_keys();
+    let inv = mod_inverse(mul);
+    obfuscated.wrapping_sub(add).wrapping_mul(inv)
+}
+
+fn mod_inverse(a: u64) -> u64 {
+    // Compute modular multiplicative inverse mod 2^64 using extended GCD.
+    // Only works when `a` is odd (guaranteed by get_keys).
+    let mut t: u64 = 0;
+    let mut new_t: u64 = 1;
+    let mut r: u128 = 1u128 << 64;
+    let mut new_r: u128 = a as u128;
+
+    while new_r != 0 {
+        let quotient = r / new_r;
+        let tmp_t = new_t;
+        new_t = t.wrapping_sub((quotient as u64).wrapping_mul(new_t));
+        t = tmp_t;
+        let tmp_r = new_r;
+        new_r = r - quotient * new_r;
+        r = tmp_r;
+    }
+
+    t
 }
 
 pub fn encode_snapshot(token: SnapshotToken) -> String {
-    let obfuscated = token.value() ^ get_key();
+    let obfuscated = obfuscate(token.value());
     format!("{obfuscated:016x}")
 }
 
 pub fn decode_snapshot(encoded: &str) -> Result<SnapshotToken, ApiError> {
+    if encoded.len() != ENCODED_TOKEN_LEN {
+        return Err(ApiError::InvalidToken);
+    }
+
     let obfuscated = u64::from_str_radix(encoded, 16).map_err(|_| ApiError::InvalidToken)?;
-    let value = obfuscated ^ get_key();
+    let value = deobfuscate(obfuscated);
 
     Ok(SnapshotToken::new(value))
 }
@@ -87,5 +129,11 @@ mod tests {
         let b = encode_snapshot(SnapshotToken::new(2));
 
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(decode_snapshot("abc").is_err());
+        assert!(decode_snapshot("0123456789abcdef0").is_err());
     }
 }

--- a/crates/kraalzibar-server/src/token.rs
+++ b/crates/kraalzibar-server/src/token.rs
@@ -1,0 +1,91 @@
+use kraalzibar_core::tuple::SnapshotToken;
+
+use crate::error::ApiError;
+
+static OBFUSCATION_KEY: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+
+fn get_key() -> u64 {
+    *OBFUSCATION_KEY.get_or_init(rand::random::<u64>)
+}
+
+pub fn encode_snapshot(token: SnapshotToken) -> String {
+    let obfuscated = token.value() ^ get_key();
+    format!("{obfuscated:016x}")
+}
+
+pub fn decode_snapshot(encoded: &str) -> Result<SnapshotToken, ApiError> {
+    let obfuscated = u64::from_str_radix(encoded, 16).map_err(|_| ApiError::InvalidToken)?;
+    let value = obfuscated ^ get_key();
+
+    Ok(SnapshotToken::new(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_round_trip() {
+        let original = SnapshotToken::new(42);
+        let encoded = encode_snapshot(original);
+        let decoded = decode_snapshot(&encoded).unwrap();
+
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn encoded_token_is_not_raw_number() {
+        let token = SnapshotToken::new(42);
+        let encoded = encode_snapshot(token);
+
+        assert_ne!(encoded, "42");
+        assert_ne!(encoded, format!("{:016x}", 42));
+    }
+
+    #[test]
+    fn encoded_token_is_hex_string() {
+        let token = SnapshotToken::new(12345);
+        let encoded = encode_snapshot(token);
+
+        assert_eq!(encoded.len(), 16);
+        assert!(encoded.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn decode_rejects_invalid_hex() {
+        let result = decode_snapshot("not-valid-hex!!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_rejects_empty_string() {
+        let result = decode_snapshot("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn round_trip_zero() {
+        let original = SnapshotToken::new(0);
+        let encoded = encode_snapshot(original);
+        let decoded = decode_snapshot(&encoded).unwrap();
+
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn round_trip_max_u64() {
+        let original = SnapshotToken::new(u64::MAX);
+        let encoded = encode_snapshot(original);
+        let decoded = decode_snapshot(&encoded).unwrap();
+
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn different_values_produce_different_encodings() {
+        let a = encode_snapshot(SnapshotToken::new(1));
+        let b = encode_snapshot(SnapshotToken::new(2));
+
+        assert_ne!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary
- Snapshot tokens were exposed as plain sequential u64 integers, leaking transaction ordering and volume (fixes #32)
- Added server-local XOR obfuscation with a random key generated at startup, encoding tokens as 16-character hex strings
- Updated both gRPC and REST API boundaries to encode outgoing tokens and decode incoming tokens
- Updated Rust client SDK to use opaque `OpaqueToken` type instead of `SnapshotToken`, treating tokens as opaque strings

## Test plan
- [x] 8 unit tests for encode/decode round-trips, edge cases (zero, max u64), invalid input rejection
- [x] Updated existing gRPC conversion tests to verify tokens are no longer raw integers
- [x] Updated existing client SDK tests for new OpaqueToken type
- [x] All 189 server lib tests pass
- [x] All 22 client lib tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)