### PR TITLE
fix: redact API key in Go SDK debug output (SEC-37)

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -31,8 +31,8 @@ func NewClient(target string, opts ...ClientOption) (*Client, error) {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 	if cfg.apiKey != "" {
-		dialOpts = append(dialOpts, grpc.WithUnaryInterceptor(apiKeyInterceptor(cfg.apiKey)))
-		dialOpts = append(dialOpts, grpc.WithStreamInterceptor(apiKeyStreamInterceptor(cfg.apiKey)))
+		dialOpts = append(dialOpts, grpc.WithUnaryInterceptor(apiKeyInterceptor(string(cfg.apiKey))))
+		dialOpts = append(dialOpts, grpc.WithStreamInterceptor(apiKeyStreamInterceptor(string(cfg.apiKey))))
 	}
 
 	conn, err := grpc.NewClient(target, dialOpts...)

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -12,6 +12,12 @@ type redactedString string
 func (r redactedString) String() string   { return "[REDACTED]" }
 func (r redactedString) GoString() string { return `redactedString("[REDACTED]")` }
 func (r redactedString) Format(f fmt.State, verb rune) {
+	if verb == 'T' {
+		fmt.Fprint(f, "kraalzibar.redactedString")
+
+		return
+	}
+
 	fmt.Fprint(f, "[REDACTED]")
 }
 
@@ -34,6 +40,12 @@ func (c clientConfig) GoString() string {
 
 // Format implements fmt.Formatter to ensure all format verbs redact the API key.
 func (c clientConfig) Format(f fmt.State, verb rune) {
+	if verb == 'T' {
+		fmt.Fprint(f, "kraalzibar.clientConfig")
+
+		return
+	}
+
 	fmt.Fprint(f, c.String())
 }
 

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -7,9 +7,17 @@ import (
 	"google.golang.org/grpc"
 )
 
+type redactedString string
+
+func (r redactedString) String() string   { return "[REDACTED]" }
+func (r redactedString) GoString() string { return `redactedString("[REDACTED]")` }
+func (r redactedString) Format(f fmt.State, verb rune) {
+	fmt.Fprint(f, "[REDACTED]")
+}
+
 type clientConfig struct {
 	insecure    bool
-	apiKey      string
+	apiKey      redactedString
 	timeout     time.Duration
 	dialOptions []grpc.DialOption
 }
@@ -22,6 +30,11 @@ func (c clientConfig) String() string {
 // GoString returns a Go-syntax representation with the API key redacted.
 func (c clientConfig) GoString() string {
 	return c.String()
+}
+
+// Format implements fmt.Formatter to ensure all format verbs redact the API key.
+func (c clientConfig) Format(f fmt.State, verb rune) {
+	fmt.Fprint(f, c.String())
 }
 
 func defaultConfig() clientConfig {
@@ -43,7 +56,7 @@ func WithInsecure() ClientOption {
 // WithAPIKey sets the Bearer token for authentication.
 func WithAPIKey(key string) ClientOption {
 	return func(c *clientConfig) {
-		c.apiKey = key
+		c.apiKey = redactedString(key)
 	}
 }
 

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -1,6 +1,7 @@
 package kraalzibar
 
 import (
+	"fmt"
 	"time"
 
 	"google.golang.org/grpc"
@@ -11,6 +12,16 @@ type clientConfig struct {
 	apiKey      string
 	timeout     time.Duration
 	dialOptions []grpc.DialOption
+}
+
+// String returns a human-readable representation with the API key redacted.
+func (c clientConfig) String() string {
+	return fmt.Sprintf("{insecure:%v apiKey:[REDACTED] timeout:%v}", c.insecure, c.timeout)
+}
+
+// GoString returns a Go-syntax representation with the API key redacted.
+func (c clientConfig) GoString() string {
+	return c.String()
 }
 
 func defaultConfig() clientConfig {

--- a/sdks/go/options_test.go
+++ b/sdks/go/options_test.go
@@ -90,6 +90,26 @@ func TestClientConfig_PlusVRedactsAPIKey(t *testing.T) {
 	}
 }
 
+func TestRedactedString_TypeVerb(t *testing.T) {
+	got := fmt.Sprintf("%T", redactedString("key"))
+
+	want := "kraalzibar.redactedString"
+	if got != want {
+		t.Errorf("%%T = %q, want %q", got, want)
+	}
+}
+
+func TestClientConfig_TypeVerb(t *testing.T) {
+	cfg := clientConfig{apiKey: "secret"}
+
+	got := fmt.Sprintf("%T", cfg)
+
+	want := "kraalzibar.clientConfig"
+	if got != want {
+		t.Errorf("%%T = %q, want %q", got, want)
+	}
+}
+
 func TestRedactedString_AllFormatVerbs(t *testing.T) {
 	secret := redactedString("super-secret-key")
 

--- a/sdks/go/options_test.go
+++ b/sdks/go/options_test.go
@@ -34,8 +34,8 @@ func TestWithAPIKey_SetsCredentials(t *testing.T) {
 	cfg := defaultConfig()
 	WithAPIKey("test-key")(&cfg)
 
-	if cfg.apiKey != "test-key" {
-		t.Errorf("expected apiKey %q, got %q", "test-key", cfg.apiKey)
+	if string(cfg.apiKey) != "test-key" {
+		t.Errorf("expected apiKey %q, got %q", "test-key", string(cfg.apiKey))
 	}
 }
 
@@ -73,5 +73,46 @@ func TestClientConfig_GoStringRedactsAPIKey(t *testing.T) {
 
 	if !strings.Contains(s, "[REDACTED]") {
 		t.Errorf("GoString() should contain [REDACTED], got: %s", s)
+	}
+}
+
+func TestClientConfig_PlusVRedactsAPIKey(t *testing.T) {
+	cfg := clientConfig{apiKey: "kraalzibar_abc_secret123"}
+
+	s := fmt.Sprintf("%+v", cfg)
+
+	if strings.Contains(s, "secret123") {
+		t.Errorf("%%+v should not contain API key, got: %s", s)
+	}
+
+	if !strings.Contains(s, "[REDACTED]") {
+		t.Errorf("%%+v should contain [REDACTED], got: %s", s)
+	}
+}
+
+func TestRedactedString_AllFormatVerbs(t *testing.T) {
+	secret := redactedString("super-secret-key")
+
+	verbs := []struct {
+		name   string
+		format string
+	}{
+		{"percent-s", "%s"},
+		{"percent-v", "%v"},
+		{"percent-plus-v", "%+v"},
+		{"percent-hash-v", "%#v"},
+		{"percent-q", "%q"},
+	}
+
+	for _, tt := range verbs {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fmt.Sprintf(tt.format, secret)
+			if strings.Contains(got, "super-secret-key") {
+				t.Errorf("format %s leaked secret: %s", tt.format, got)
+			}
+			if !strings.Contains(got, "REDACTED") {
+				t.Errorf("format %s missing REDACTED: %s", tt.format, got)
+			}
+		})
 	}
 }

--- a/sdks/go/options_test.go
+++ b/sdks/go/options_test.go
@@ -1,6 +1,8 @@
 package kraalzibar
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -43,5 +45,33 @@ func TestWithTimeout_SetsDeadline(t *testing.T) {
 
 	if cfg.timeout != 5*time.Second {
 		t.Errorf("expected timeout 5s, got %v", cfg.timeout)
+	}
+}
+
+func TestClientConfig_StringRedactsAPIKey(t *testing.T) {
+	cfg := clientConfig{apiKey: "kraalzibar_abc_secret123"}
+
+	s := fmt.Sprintf("%v", cfg)
+
+	if strings.Contains(s, "secret123") {
+		t.Errorf("String() should not contain API key, got: %s", s)
+	}
+
+	if !strings.Contains(s, "[REDACTED]") {
+		t.Errorf("String() should contain [REDACTED], got: %s", s)
+	}
+}
+
+func TestClientConfig_GoStringRedactsAPIKey(t *testing.T) {
+	cfg := clientConfig{apiKey: "kraalzibar_abc_secret123"}
+
+	s := fmt.Sprintf("%#v", cfg)
+
+	if strings.Contains(s, "secret123") {
+		t.Errorf("GoString() should not contain API key, got: %s", s)
+	}
+
+	if !strings.Contains(s, "[REDACTED]") {
+		t.Errorf("GoString() should contain [REDACTED], got: %s", s)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `String()` and `GoString()` methods on `clientConfig` that redact the API key
- Prevents accidental key exposure via `%v`, `%+v`, or `%#v` formatting

Closes #37

## Test plan
- [x] Test verifies `String()` output contains `[REDACTED]` and not the actual key
- [x] `go test ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)