### PR TITLE
fix: resolve flaky audit test and CI docker-compose env vars

### DIFF
--- a/crates/kraalzibar-server/src/audit.rs
+++ b/crates/kraalzibar-server/src/audit.rs
@@ -60,7 +60,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use tracing_subscriber::layer::SubscriberExt;
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     struct CapturedEvent {
         target: String,
         _message: String,
@@ -123,7 +123,7 @@ mod tests {
         };
         let subscriber = tracing_subscriber::registry().with(layer);
         tracing::subscriber::with_default(subscriber, f);
-        Arc::try_unwrap(events).unwrap().into_inner().unwrap()
+        events.lock().unwrap().clone()
     }
 
     fn has_field(event: &CapturedEvent, key: &str, value: &str) -> bool {


### PR DESCRIPTION
## Summary
- Fix flaky `audit_auth_failure_includes_reason` test by replacing `Arc::try_unwrap().unwrap()` with `lock().clone()` — avoids race condition when tracing subscriber reference outlives the test closure
- Set `POSTGRES_PASSWORD` env var in integration workflow for docker-compose (required after SEC-35 removed default credentials)

## Test plan
- [x] All audit tests pass locally
- [x] clippy clean, fmt clean
- [x] Integration workflow will work with docker-compose requiring `POSTGRES_PASSWORD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)