### PR TITLE
fix: pin Tempo image to v2.7.2 to prevent CI breakage

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     restart: unless-stopped
 
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.7.2
     command: ["-config.file=/etc/tempo.yml"]
     volumes:
       - ./tempo.yml:/etc/tempo.yml:ro


### PR DESCRIPTION
## Summary
- Pin `grafana/tempo` from `latest` to `2.7.2` in docker-compose
- `latest` started crashing in CI (container exits with code 1), likely due to a config format change in a newer release

## Test plan
- [x] Docker Build & Health Check CI should pass with pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)